### PR TITLE
Add placeholder routers for model and user

### DIFF
--- a/Backend/model_predict.py
+++ b/Backend/model_predict.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+model_router = APIRouter()
+
+@model_router.post("")
+def predict_placeholder():
+    """Placeholder endpoint for model predictions."""
+    return {"detail": "model prediction placeholder"}

--- a/Backend/users.py
+++ b/Backend/users.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+user_router = APIRouter()
+
+@user_router.get("/me")
+def read_current_user():
+    """Placeholder endpoint for retrieving current user info."""
+    return {"detail": "user info placeholder"}


### PR DESCRIPTION
## Summary
- create `model_predict.py` with placeholder router
- create `users.py` with placeholder router
- wire the routers in `app.py`

## Testing
- `python3 -m py_compile Backend/app.py Backend/auth.py Backend/model_predict.py Backend/users.py`

------
https://chatgpt.com/codex/tasks/task_e_6859540bf410832797a39f1ddff27727