### PR TITLE
Use relative DATA_PATH with env override

### DIFF
--- a/Backend/ml_model_api.py
+++ b/Backend/ml_model_api.py
@@ -2,6 +2,8 @@
 
 import os
 import random
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import shap
@@ -18,7 +20,17 @@ from sklearn.preprocessing import LabelEncoder
 app = FastAPI()
 
 # --- Load Dataset ---
-DATA_PATH = "C:/Fruad detection_1st_prototype/data/merged_Fullcover.csv"
+env_data_path = os.environ.get("DATA_PATH")
+if env_data_path:
+    DATA_PATH = Path(env_data_path)
+else:
+    DATA_PATH = Path(__file__).parent / "data" / "merged_Fullcover.csv"
+
+if not DATA_PATH.is_file():
+    raise FileNotFoundError(
+        f"Data file not found at {DATA_PATH}. Set DATA_PATH environment variable to override."
+    )
+
 df3 = pd.read_csv(DATA_PATH)
 
 # --- Risk Lists ---


### PR DESCRIPTION
## Summary
- update `Backend/ml_model_api.py` to load dataset using a relative path
- allow overriding the path via the `DATA_PATH` environment variable
- add a helpful error if the data file is missing

## Testing
- `python3 -m py_compile Backend/ml_model_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68595413e5d483278460c5f9672b4916