### PR TITLE
Add ML integration and prediction logging

### DIFF
--- a/Backend/data/merged_Fullcover.csv
+++ b/Backend/data/merged_Fullcover.csv
@@ -1,0 +1,7 @@
+DESCRIPTION_med,ENCOUNTERCLASS,PROVIDER,ORGANIZATION,GENDER,ETHNICITY,MARITAL,STATE,AGE,DISPENSES,BASE_COST,TOTALCOST,PATIENT_med
+Oxycodone Hydrochloride,inpatient,Dr.A,City Health,M,white,M,Massachusetts,45,1,10,10,demo_patient_01
+Ibuprofen,outpatient,Dr.B,City Health,F,white,S,Massachusetts,37,2,5,10,demo_patient_02
+Morphine Sulfate,emergency,Dr.C,County Clinic,M,black,M,Massachusetts,60,1,15,15,demo_patient_01
+Warfarin,outpatient,Dr.D,County Clinic,F,asian,S,Massachusetts,23,1,3,3,demo_patient_03
+Tramadol Hydrochloride,inpatient,Dr.E,City Health,M,hispanic,M,Massachusetts,50,3,8,24,demo_patient_04
+Lisinopril,outpatient,Dr.F,City Health,F,white,S,Massachusetts,34,2,4,8,demo_patient_05

--- a/Backend/model_predict.py
+++ b/Backend/model_predict.py
@@ -1,8 +1,25 @@
 from fastapi import APIRouter
+from datetime import datetime
+from pathlib import Path
+import csv
+
+from ml_model_api import FraudInput, predict_fraud
 
 model_router = APIRouter()
 
+PRED_FILE = Path(__file__).parent / "predictions.csv"
+
 @model_router.post("")
-def predict_placeholder():
-    """Placeholder endpoint for model predictions."""
-    return {"detail": "model prediction placeholder"}
+def predict(input_data: FraudInput):
+    result = predict_fraud(input_data)
+    record = input_data.dict()
+    record.update(result)
+    record["timestamp"] = datetime.utcnow().isoformat()
+    file_exists = PRED_FILE.is_file()
+    with open(PRED_FILE, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=record.keys())
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow(record)
+    return result
+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ GET /user/...             (Optional) User routes
 ✅ SHAP-based feature importance visualization
 ✅ Streamlined UI with TailwindCSS and React Router
 ✅ Secure CORS connection between frontend-backend
+✅ Predictions logged to `Backend/predictions.csv`
 
 🔐 Default Login (for testing)
 ```json


### PR DESCRIPTION
## Summary
- hook up the frontend new prescription form to the backend
- implement prediction endpoint and store results in `predictions.csv`
- provide a small example dataset for the model
- document new logging feature

## Testing
- `python -m py_compile Backend/*.py`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685958ecf938832787251d1e83da771d