### PR TITLE
Add page animations

### DIFF
--- a/Frontend/src/components/TrendingBanner.jsx
+++ b/Frontend/src/components/TrendingBanner.jsx
@@ -1,20 +1,4 @@
-import { useEffect, useRef } from 'react';
-
 export default function TrendingBanner() {
-  const scrollRef = useRef(null);
-
-  useEffect(() => {
-    const container = scrollRef.current;
-    if (!container) return;
-    const interval = setInterval(() => {
-      container.scrollLeft += 1;
-      if (container.scrollLeft >= container.scrollWidth - container.clientWidth) {
-        container.scrollLeft = 0;
-      }
-    }, 20);
-    return () => clearInterval(interval);
-  }, []);
-
   const items = [
     '💊 Pregabalin misuse spikes in urban clinics',
     '♻️ Pharma companies adopt sustainable packaging',
@@ -23,11 +7,8 @@ export default function TrendingBanner() {
 
   return (
     <div className="bg-gradient-to-r from-pink-500 to-yellow-500 overflow-hidden">
-      <div
-        ref={scrollRef}
-        className="whitespace-nowrap overflow-x-scroll no-scrollbar py-2"
-      >
-        {items.map((item, idx) => (
+      <div className="whitespace-nowrap flex animate-marquee py-2">
+        {items.concat(items).map((item, idx) => (
           <span key={idx} className="text-white font-bold mx-4">
             {item}
           </span>

--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -117,7 +117,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 animate-fadeIn">
       <section className="bg-gradient-to-r from-gray-900 to-black text-white rounded-lg p-6 shadow mb-8">
         <h2 className="text-2xl font-bold">Dashboard Overview</h2>
         <p className="text-sm text-white/80">Latest fraud prediction statistics</p>
@@ -126,7 +126,7 @@ export default function Home() {
       {/* Top KPI Cards */}
       <div className="grid gap-6 md:grid-cols-3">
         {kpis.map((kpi) => (
-          <div key={kpi.label} className="bg-gray-800 p-4 rounded-lg shadow flex items-center justify-between">
+          <div key={kpi.label} className="bg-gray-800 p-4 rounded-lg shadow flex items-center justify-between transition-transform hover:scale-105">
             <div>
               <p className="text-sm text-gray-400">{kpi.label}</p>
               <p className="text-2xl font-semibold text-white">{kpi.value}</p>
@@ -176,7 +176,7 @@ export default function Home() {
           </thead>
           <tbody>
             {flagged.map((row) => (
-              <tr key={row.id} className="border-t">
+              <tr key={row.id} className="border-t hover:bg-gray-700 transition-colors">
                 <td className="py-2 font-medium">{row.id}</td>
                 <td className="py-2">{row.patient}</td>
                 <td className="py-2">

--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -5,7 +5,22 @@ export default {
     './src/**/*.{js,jsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        marquee: {
+          '0%': { transform: 'translateX(0)' },
+          '100%': { transform: 'translateX(-50%)' },
+        },
+        fadeIn: {
+          from: { opacity: 0, transform: 'translateY(10px)' },
+          to: { opacity: 1, transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        marquee: 'marquee 20s linear infinite',
+        fadeIn: 'fadeIn 0.5s ease-out forwards',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add marquee effect in TrendingBanner
- allow fade-in and hover effects on Home page
- define Tailwind animations

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c1f58f67883279d31403106174cbb