### PR TITLE
Add fraud check popup component

### DIFF
--- a/Frontend/src/components/PredictionPopup.jsx
+++ b/Frontend/src/components/PredictionPopup.jsx
@@ -1,0 +1,23 @@
+export default function PredictionPopup({ result, onClose }) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white text-gray-900 rounded-lg p-6 w-80 max-w-full">
+        <h2 className="text-xl font-semibold mb-4">Prediction Result</h2>
+        <p className="mb-1"><span className="font-medium">Risk Score:</span> {result.risk_score}</p>
+        <p className="mb-1"><span className="font-medium">Medication Risk:</span> {result.medication_risk}</p>
+        <p>
+          <span className="font-medium">Fraudulent:</span>
+          <span className={result.fraud || result.fraudulent ? 'text-red-600 font-semibold ml-1' : 'text-black ml-1'}>
+            {result.fraud || result.fraudulent ? 'Yes' : 'No'}
+          </span>
+        </p>
+        <button
+          onClick={onClose}
+          className="mt-4 px-4 py-2 bg-gray-800 text-white rounded hover:bg-gray-700"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/components/PrescriptionForm.jsx
+++ b/Frontend/src/components/PrescriptionForm.jsx
@@ -1,5 +1,40 @@
+import { useState } from 'react';
+import PredictionPopup from './PredictionPopup';
+
 export default function PrescriptionForm() {
+  const [prediction, setPrediction] = useState(null);
+
+  const handleCheck = async () => {
+    const payload = {
+      PATIENT_ID: 'demo_patient_01',
+      DESCRIPTION_med: 'Oxycodone Hydrochloride 10 MG',
+    };
+
+    try {
+      const res = await fetch('/api/predict', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      setPrediction(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
-    <div>PrescriptionForm component</div>
+    <div className="bg-gray-800 p-6 rounded-lg text-gray-100 max-w-md mx-auto">
+      <h1 className="text-xl font-semibold mb-4">Prescription Fraud Detection</h1>
+      <button
+        onClick={handleCheck}
+        className="w-full bg-gray-700 text-white py-2 rounded-md hover:bg-gray-600"
+      >
+        AI Fraud Check
+      </button>
+      {prediction && (
+        <PredictionPopup result={prediction} onClose={() => setPrediction(null)} />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement `PredictionPopup` component with Tailwind modal
- implement `PrescriptionForm` with API call to `/api/predict`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e4dbd57148327b31d45c54ce864a8