### PR TITLE
Replace navbar logo and remove theme toggle

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.2",
         "tailwindcss": "^4.1.10"
       },
@@ -3058,6 +3059,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -16,6 +16,7 @@
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2",
     "tailwindcss": "^4.1.10"
   },

--- a/Frontend/src/components/Navbar.jsx
+++ b/Frontend/src/components/Navbar.jsx
@@ -7,37 +7,17 @@ import {
   Settings,
   LogOut,
   Search,
-  Sun,
-  Moon,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { MdLocalPharmacy } from 'react-icons/md';
 
 export default function Navbar() {
-  const [theme, setTheme] = useState('dark');
-
-  useEffect(() => {
-    const saved = localStorage.getItem('theme');
-    if (saved) setTheme(saved);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (theme === 'dark') {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
-    }
-    localStorage.setItem('theme', theme);
-  }, [theme]);
-
-  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
 
   return (
 
     <nav className="bg-black text-white w-full">
       <div className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3 space-x-4">
         <div className="flex items-center space-x-2 whitespace-nowrap">
-          <img src="/favicon.svg" alt="logo" className="w-6 h-6" />
+          <MdLocalPharmacy className="w-6 h-6" />
           <span className="font-bold">AI-PrescripSafe</span>
         </div>
         <div className="flex-1 max-w-md hidden sm:block">
@@ -51,33 +31,30 @@ export default function Navbar() {
           </div>
         </div>
         <div className="flex items-center space-x-4 text-sm">
-          <Link to="/" className="flex items-center gap-1 hover:text-pink-400 transition">
+          <Link to="/" className="flex items-center gap-1 mx-3 hover:text-pink-400 transition">
             <Home className="w-5 h-5" />
             <span className="hidden sm:inline">Home</span>
           </Link>
-          <Link to="/new" className="flex items-center gap-1 hover:text-pink-400 transition">
+          <Link to="/new" className="flex items-center gap-1 mx-3 hover:text-pink-400 transition">
             <PlusCircle className="w-5 h-5" />
             <span className="hidden sm:inline">New</span>
           </Link>
-          <Link to="/dashboard" className="flex items-center gap-1 hover:text-pink-400 transition">
+          <Link to="/dashboard" className="flex items-center gap-1 mx-3 hover:text-pink-400 transition">
             <LayoutDashboard className="w-5 h-5" />
             <span className="hidden sm:inline">Dashboard</span>
           </Link>
-          <Link to="/profile" className="flex items-center gap-1 hover:text-pink-400 transition">
+          <Link to="/profile" className="flex items-center gap-1 mx-3 hover:text-pink-400 transition">
             <User className="w-5 h-5" />
             <span className="hidden sm:inline">Profile</span>
           </Link>
-          <Link to="/settings" className="flex items-center gap-1 hover:text-pink-400 transition">
+          <Link to="/settings" className="flex items-center gap-1 mx-3 hover:text-pink-400 transition">
             <Settings className="w-5 h-5" />
             <span className="hidden sm:inline">Settings</span>
           </Link>
-          <Link to="/logout" className="flex items-center gap-1 hover:text-pink-400 transition">
+          <Link to="/logout" className="flex items-center gap-1 mx-3 hover:text-pink-400 transition">
             <LogOut className="w-5 h-5" />
             <span className="hidden sm:inline">Logout</span>
           </Link>
-          <button onClick={toggleTheme} className="flex items-center gap-1 hover:text-pink-400 transition">
-            {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
-          </button>
 
         </div>
       </div>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cd Frontend
 npm install
 npm run dev
 ```
+If you see errors about missing modules such as `react-icons/md`, rerun `npm install` to make sure all dependencies are present.
 ✅ Frontend runs at: http://localhost:5173
 
 📌 API Routes


### PR DESCRIPTION
## Summary
- add `react-icons` to dependencies
- swap the brand icon for `MdLocalPharmacy`
- remove the dark/light toggle from the navbar
- add `mx-3` spacing around navigation links
- note about installing dependencies when encountering missing icon imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e4eb72c948327aed6eeac3fce288f