### PR TITLE
Add fraud prediction modal and form component

### DIFF
--- a/Frontend/src/components/PredictionPopup.jsx
+++ b/Frontend/src/components/PredictionPopup.jsx
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+
+export default function PredictionPopup({ result, onClose }) {
+  if (!result) return null;
+  const fraudulent = result.fraud === true || result.fraud === 'True' || result.fraud === 'Yes';
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50">
+      <div className="bg-white rounded-lg p-6 w-80 text-gray-900 shadow-lg">
+        <h2 className="text-xl font-semibold mb-4 text-center">Prediction Result</h2>
+        <p className="mb-2">Risk Score: <span className="font-medium">{result.risk_score}</span></p>
+        <p className="mb-2">Medication Risk: <span className="font-medium">{result.medication_risk}</span></p>
+        <p className={`mb-4 font-medium ${fraudulent ? 'text-red-600' : 'text-black'}`}>Fraudulent: {fraudulent ? 'Yes' : 'No'}</p>
+        <button onClick={onClose} className="bg-gray-800 text-white w-full py-2 rounded hover:bg-gray-700">Close</button>
+      </div>
+    </div>
+  );
+}
+
+PredictionPopup.propTypes = {
+  result: PropTypes.shape({
+    risk_score: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    medication_risk: PropTypes.string,
+    fraud: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  }),
+  onClose: PropTypes.func.isRequired,
+};

--- a/Frontend/src/components/PrescriptionForm.jsx
+++ b/Frontend/src/components/PrescriptionForm.jsx
@@ -1,5 +1,49 @@
+import { useState } from 'react';
+import PredictionPopup from './PredictionPopup';
+
 export default function PrescriptionForm() {
+  const [result, setResult] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payload = {
+      PATIENT_med: 'demo_patient_01',
+      DESCRIPTION_med: 'Oxycodone Hydrochloride 10 MG',
+      PROVIDER: 'Dr. ABC',
+      DISPENSES: 1,
+    };
+
+    try {
+      const res = await fetch('/api/predict', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      setResult(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
-    <div>PrescriptionForm component</div>
+    <div className="max-w-md mx-auto p-6 bg-gray-800 text-white rounded-lg">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Patient ID</label>
+          <input type="text" className="w-full input-style" defaultValue="demo_patient_01" readOnly />
+        </div>
+        <div>
+          <label className="block mb-1">Medication</label>
+          <input type="text" className="w-full input-style" defaultValue="Oxycodone Hydrochloride 10 MG" readOnly />
+        </div>
+        <button type="submit" className="w-full bg-gray-700 py-2 rounded hover:bg-gray-600">
+          AI Fraud Check
+        </button>
+      </form>
+      {result && (
+        <PredictionPopup result={result} onClose={() => setResult(null)} />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement `PredictionPopup` modal for displaying prediction results
- implement new `PrescriptionForm` component that posts to `/api/predict`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e55f3647c8327bafef580332bc03e