### PR TITLE
Improve dashboard interactivity

### DIFF
--- a/Frontend/src/components/FlaggedTable.jsx
+++ b/Frontend/src/components/FlaggedTable.jsx
@@ -1,5 +1,93 @@
-export default function FlaggedTable() {
+import PropTypes from 'prop-types';
+import { useMemo } from 'react';
+import { Star, AlertTriangle } from 'lucide-react';
+
+export default function FlaggedTable({ rows, statusFilter, onStatusChange, search, onSearchChange, onReview }) {
+  const filtered = useMemo(() => {
+    return rows
+      .filter(r => (statusFilter === 'All' ? true : r.status === statusFilter))
+      .filter(r =>
+        r.id.toLowerCase().includes(search.toLowerCase()) ||
+        r.patient.toLowerCase().includes(search.toLowerCase())
+      );
+  }, [rows, statusFilter, search]);
+
   return (
-    <div>FlaggedTable component</div>
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2 items-center justify-between">
+        <div className="flex gap-2">
+          {['All','Flagged','Cleared'].map(st => (
+            <button
+              key={st}
+              type="button"
+              onClick={() => onStatusChange(st)}
+              className={`px-2 py-1 text-xs rounded ${statusFilter===st ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-200'}`}
+            >
+              {st}
+            </button>
+          ))}
+        </div>
+        <input
+          type="text"
+          value={search}
+          onChange={e => onSearchChange(e.target.value)}
+          placeholder="Search by ID or patient"
+          className="bg-gray-700 p-1 rounded text-sm placeholder-gray-400"
+        />
+      </div>
+      <div className="overflow-y-auto max-h-[600px]">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-gray-300">
+            <tr>
+              <th className="py-2">Prescription ID</th>
+              <th className="py-2">Patient</th>
+              <th className="py-2">Status</th>
+              <th className="py-2">Fraud Risk</th>
+              <th className="py-2">Flag</th>
+              <th className="py-2">Doctor</th>
+              <th className="py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(row => (
+              <tr key={row.id} className="border-t hover:bg-slate-700 hover:ring cursor-pointer">
+                <td className="py-2 font-medium">{row.id}</td>
+                <td className="py-2">{row.patient}</td>
+                <td className="py-2">
+                  <span className={`px-2 py-0.5 text-xs rounded-full ${row.status==='Flagged' ? 'bg-red-600 text-white' : 'bg-green-500 text-white'}`}>{row.status}</span>
+                </td>
+                <td className="py-2" title={`${row.risk} out of 5 risk level`}>
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Star key={i} className={`w-4 h-4 inline ${i < row.risk ? 'text-yellow-400' : 'text-gray-400'}`} />
+                  ))}
+                </td>
+                <td className="py-2">
+                  {row.status==='Flagged' && <AlertTriangle className="text-red-600 w-5 h-5" title="Flagged due to high dose" />}
+                </td>
+                <td className="py-2">{row.doctor}</td>
+                <td className="py-2">
+                  <button
+                    type="button"
+                    onClick={() => onReview(row)}
+                    className="bg-blue-600 text-white px-3 py-1 rounded-md text-xs hover:bg-blue-500"
+                  >
+                    Review
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 }
+
+FlaggedTable.propTypes = {
+  rows: PropTypes.array.isRequired,
+  statusFilter: PropTypes.string.isRequired,
+  onStatusChange: PropTypes.func.isRequired,
+  search: PropTypes.string.isRequired,
+  onSearchChange: PropTypes.func.isRequired,
+  onReview: PropTypes.func.isRequired,
+};

--- a/Frontend/src/components/MedicationChart.jsx
+++ b/Frontend/src/components/MedicationChart.jsx
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import { Doughnut } from 'react-chartjs-2';
+
+export default function MedicationChart({ data, onSelect }) {
+  const options = {
+    plugins: { legend: { display: false } },
+    cutout: '60%',
+    onClick: (_evt, elements) => {
+      if (!elements.length) return;
+      const idx = elements[0].index;
+      onSelect(data.labels[idx]);
+    },
+  };
+
+  return (
+    <div className="md:flex md:items-start">
+      <div className="md:w-1/2 mx-auto">
+        <Doughnut data={data} options={options} />
+      </div>
+      <ul className="md:w-1/2 space-y-2 mt-4 md:mt-0 md:pl-6 text-sm">
+        {data.labels.map((label, idx) => (
+          <li key={label} className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span
+                className="inline-block w-3 h-3 rounded-sm"
+                style={{ backgroundColor: data.datasets[0].backgroundColor[idx] }}
+              ></span>
+              <button
+                type="button"
+                onClick={() => onSelect(label)}
+                className="hover:underline text-left"
+              >
+                {label}
+              </button>
+            </div>
+            <span className="text-gray-400">
+              {data.datasets[0].data[idx]}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+MedicationChart.propTypes = {
+  data: PropTypes.object.isRequired,
+  onSelect: PropTypes.func,
+};
+
+MedicationChart.defaultProps = {
+  onSelect: () => {},
+};

--- a/Frontend/src/components/RiskTrendChart.jsx
+++ b/Frontend/src/components/RiskTrendChart.jsx
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import { Line } from 'react-chartjs-2';
+
+export default function RiskTrendChart({ data, lastUpdated }) {
+  const options = {
+    plugins: { legend: { display: false } },
+    scales: {
+      x: { ticks: { color: '#ffffff' } },
+      y: { ticks: { color: '#ffffff' }, beginAtZero: true },
+    },
+    animation: { duration: 500 },
+  };
+
+  return (
+    <div>
+      <Line data={data} options={options} />
+      <p className="text-xs text-gray-400 mt-2">Last Updated: {lastUpdated}</p>
+    </div>
+  );
+}
+
+RiskTrendChart.propTypes = {
+  data: PropTypes.object.isRequired,
+  lastUpdated: PropTypes.string.isRequired,
+};


### PR DESCRIPTION
## Summary
- add MedicationChart, RiskTrendChart and enhanced FlaggedTable components
- refactor Dashboard to use new components and add search/filter
- implement modal review panel and CSV export button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e5c7931c48327bdc00a8634427b52