### PR TITLE
Fix /predict 422 error with defaults for missing fields

### DIFF
--- a/Backend/ml_model_api.py
+++ b/Backend/ml_model_api.py
@@ -125,25 +125,28 @@ def infer_fraud_type(entry):
 # --- Input Schema (NO engineered features included) ---
 class FraudInput(BaseModel):
     DESCRIPTION_med: str
-    ENCOUNTERCLASS: str
-    PROVIDER: str
-    ORGANIZATION: str
-    GENDER: str
-    ETHNICITY: str
-    MARITAL: str
-    STATE: str
-    AGE: int
-    DISPENSES: float
-    BASE_COST: float
-    TOTALCOST: float
+    ENCOUNTERCLASS: str | None = "unknown"
+    PROVIDER: str | None = "unknown"
+    ORGANIZATION: str | None = "unknown"
+    GENDER: str | None = "unknown"
+    ETHNICITY: str | None = "unknown"
+    MARITAL: str | None = "unknown"
+    STATE: str | None = "unknown"
+    AGE: int | None = 0
+    DISPENSES: float | None = 0.0
+    BASE_COST: float | None = 0.0
+    TOTALCOST: float | None = 0.0
     PATIENT_med: str
-    DATE: str
+    DATE: str | None = None
 
 # --- Predict Endpoint ---
 @app.post("/predict")
 async def predict_fraud(input: FraudInput):
     entry = input.dict()
-    entry["DATE"] = pd.to_datetime(entry["DATE"])
+    if not entry.get("DATE"):
+        entry["DATE"] = pd.Timestamp.today()
+    else:
+        entry["DATE"] = pd.to_datetime(entry["DATE"])
     entry_date = entry["DATE"].date()
 
     # --- Check for duplicate dispensing via prediction log ---

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -5,3 +5,4 @@ numpy
 shap
 scikit-learn
 matplotlib
+python-multipart


### PR DESCRIPTION
## Summary
- allow optional fields in `FraudInput` model
- handle missing `DATE` in `predict_fraud`
- include `python-multipart` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630324ebf4832781260bf4e782e485