### PR TITLE
Fix patient ID medication checks

### DIFF
--- a/Backend/ml_model_api.py
+++ b/Backend/ml_model_api.py
@@ -154,18 +154,20 @@ async def predict_fraud(input: FraudInput):
     entry_date = entry["DATE"].date()
 
     # --- Check for duplicate dispensing via prediction log ---
-    log_path = LOG_FILE
+    # Look for potential duplicates in the existing prediction logs
+    # (predictions.csv). This CSV acts as our simple history store
+    # since no database is used.
+    log_path = PRED_FILE
     duplicate_exists = False
     if log_path.exists():
         with open(log_path, mode="r") as f:
             reader = csv.DictReader(f)
             for row in reader:
+                parsed_date = pd.to_datetime(row["DATE"]).date()
                 if (
-                    row["PATIENT_med"].strip() == entry["PATIENT_med"].strip()
-                    and row["DESCRIPTION_med"].strip().lower()
-                    == entry["DESCRIPTION_med"].strip().lower()
-                    and abs((pd.to_datetime(row["DATE"]).date() - entry_date).days)
-                    <= 7
+                    row["PATIENT_med"] == entry["PATIENT_med"]
+                    and row["DESCRIPTION_med"] == entry["DESCRIPTION_med"]
+                    and abs((parsed_date - entry_date).days) <= 7
                 ):
                     duplicate_exists = True
                     break


### PR DESCRIPTION
## Summary
- deduplicate by patient and medication using `predictions.csv`
- keep patient and medication fields in prediction logs

## Testing
- `python -m py_compile Backend/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863101a8abc8327b515d7e847eb1552