### PR TITLE
Fix duplicate dispensing fraud detection

### DIFF
--- a/Backend/model_predict.py
+++ b/Backend/model_predict.py
@@ -76,6 +76,9 @@ def predict(input_data: FraudInput):
                 break
     if duplicate_flag:
         flags.append(duplicate_flag)
+        # mark as fraudulent when duplicate dispensing is found
+        result["fraud"] = True
+        record["fraud"] = True
 
     # --- 2. Doctor Shopping ---
     provider_set = set()


### PR DESCRIPTION
## Summary
- mark prescription as fraudulent when duplicate dispensing is found

## Testing
- `python3 -m py_compile Backend/model_predict.py Backend/ml_model_api.py Backend/app.py Backend/auth.py Backend/users.py`


------
https://chatgpt.com/codex/tasks/task_e_6863b2e10d4083278688b94e57117ee8