### PR TITLE
Add flags display in prediction popup

### DIFF
--- a/Frontend/src/components/PredictionPopup.jsx
+++ b/Frontend/src/components/PredictionPopup.jsx
@@ -9,7 +9,17 @@ export default function PredictionPopup({ result, onClose }) {
         <h2 className="text-xl font-semibold mb-4 text-center">Prediction Result</h2>
         <p className="mb-2">Risk Score: <span className="font-medium">{result.risk_score}</span></p>
         <p className="mb-2">Medication Risk: <span className="font-medium">{result.medication_risk}</span></p>
-        <p className={`mb-4 font-medium ${fraudulent ? 'text-red-600' : 'text-black'}`}>Fraudulent: {fraudulent ? 'Yes' : 'No'}</p>
+        <p className={`mb-2 font-medium ${fraudulent ? 'text-red-600' : 'text-black'}`}>Fraudulent: {fraudulent ? 'Yes' : 'No'}</p>
+        {Array.isArray(result.flags) && result.flags.length > 0 && (
+          <div className="mb-4">
+            <p className="font-medium">Flags:</p>
+            <ul className="list-disc list-inside text-sm mt-1">
+              {result.flags.map((flag, idx) => (
+                <li key={idx}>{flag}</li>
+              ))}
+            </ul>
+          </div>
+        )}
         <button onClick={onClose} className="bg-gray-800 text-white w-full py-2 rounded hover:bg-gray-700">Close</button>
       </div>
     </div>
@@ -21,6 +31,7 @@ PredictionPopup.propTypes = {
     risk_score: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     medication_risk: PropTypes.string,
     fraud: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    flags: PropTypes.arrayOf(PropTypes.string),
   }),
   onClose: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Summary
- show `flags` list in `PredictionPopup` if present
- update prop-types for the popup component
- run eslint to ensure formatting

## Testing
- `npm --prefix Frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863b44548248327b439ebf8a891a300