### PR TITLE
Add RC flag and badge for rare cases

### DIFF
--- a/Backend/model_predict.py
+++ b/Backend/model_predict.py
@@ -58,7 +58,7 @@ def predict(input_data: FraudInput):
 
     # --- Rare Condition Bypass ---
     if record["PATIENT_med"] in RARE_CASE_PATIENTS:
-        flags = ["Patient is exempted due to a known rare condition"]
+        flags = ["RC"]
         record["likely_fraud"] = False
         result["fraud"] = False
         record["fraud"] = False

--- a/Frontend/src/components/FlaggedTable.jsx
+++ b/Frontend/src/components/FlaggedTable.jsx
@@ -54,11 +54,13 @@ export default function FlaggedTable({ rows, statusFilter, onStatusChange, searc
                 <td className="py-2 font-medium">{row.id}</td>
                 <td className="py-2">{row.patient}</td>
                 <td className="py-2">
-                  <span
-                    className={`px-2 py-0.5 text-xs rounded-full ${row.rare ? 'bg-yellow-600 text-white' : row.status==='Flagged' ? 'bg-red-600 text-white' : 'bg-green-500 text-white'}`}
-                  >
-                    {row.rare ? 'Rare condition' : row.status}
-                  </span>
+                  {row.flags?.includes('RC') ? (
+                    <span className="status-tag rare">RC</span>
+                  ) : row.likely_fraud ? (
+                    <span className="status-tag flagged">Flagged</span>
+                  ) : (
+                    <span className="status-tag cleared">Cleared</span>
+                  )}
                 </td>
                 <td className="py-2" title={`${row.risk} out of 5 risk level`}>
                   {Array.from({ length: 5 }).map((_, i) => (

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -26,3 +26,26 @@ body {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+.status-tag {
+  padding: 2px 6px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.status-tag.flagged {
+  background-color: #dc2626;
+  color: white;
+}
+
+.status-tag.cleared {
+  background-color: #22c55e;
+  color: white;
+}
+
+.status-tag.rare {
+  background-color: #e09110;
+  color: white;
+}
+

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -69,7 +69,14 @@ export default function Dashboard() {
       if (res.ok) {
         setRows((prev) =>
           prev.map((r) =>
-            r.id === selectedRow.id ? { ...r, rare: true, status: 'Cleared' } : r
+            r.id === selectedRow.id
+              ? {
+                  ...r,
+                  flags: 'RC',
+                  likely_fraud: false,
+                  status: 'Cleared',
+                }
+              : r
           )
         );
         setSelectedRow(null);
@@ -102,13 +109,15 @@ export default function Dashboard() {
           data.map((r, i) => ({
             id: `RX${String(i + 1).padStart(3, '0')}`,
             patient: r.PATIENT_med,
-            status: r.fraud === 'True' || r.fraud === true ? 'Flagged' : 'Cleared',
             risk: Math.min(5, Math.round(Number(r.risk_score) / 20)),
             doctor: r.PROVIDER,
             medication: r.DESCRIPTION_med,
-            rare: Array.isArray(r.flags)
-              ? r.flags.includes('Patient is exempted due to a known rare condition')
-              : r.flags?.includes('rare condition'),
+            flags: r.flags,
+            likely_fraud: r.likely_fraud === 'True' || r.likely_fraud === true,
+            status:
+              r.likely_fraud === 'True' || r.likely_fraud === true
+                ? 'Flagged'
+                : 'Cleared',
           }))
         );
         const totalRecords = data.length;


### PR DESCRIPTION
## Summary
- compress rare condition flag to `RC` in the backend
- include flags and likely fraud fields in dashboard rows
- update bypass logic to mark rows with `RC`
- show RC badge in `FlaggedTable`
- style status tags in CSS

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile Backend/model_predict.py`

------
https://chatgpt.com/codex/tasks/task_e_6863d057aef4832786436e5baa5d280c