### PR TITLE
Update RC badge styling

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -31,7 +31,11 @@ body {
   padding: 2px 6px;
   border-radius: 5px;
   font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1;
+  display: inline-block;
   white-space: nowrap;
+  text-align: center;
 }
 
 .status-tag.flagged {
@@ -45,7 +49,7 @@ body {
 }
 
 .status-tag.rare {
-  background-color: #e09110;
+  background-color: #f39c12;
   color: white;
 }
 


### PR DESCRIPTION
## Summary
- emphasize common `.status-tag` style for badges
- support orange `rare` badge color and bold font

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863d33909d48327b9ecf3d507e48e02