### PR TITLE
Enhance fraud chart visuals

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.10",
         "chart.js": "^4.5.0",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "lucide-react": "^0.522.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
@@ -1825,6 +1826,15 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/chownr": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
     "chart.js": "^4.5.0",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "lucide-react": "^0.522.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",

--- a/Frontend/src/components/FraudMedsBarChart.jsx
+++ b/Frontend/src/components/FraudMedsBarChart.jsx
@@ -8,18 +8,38 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend, ChartDataLabels);
 
 export default function FraudMedsBarChart({ data, onSelect }) {
   const options = {
     indexAxis: 'y',
+    responsive: true,
+    maintainAspectRatio: false,
     plugins: {
       legend: { display: false },
       tooltip: {
+        backgroundColor: '#1f2937',
+        titleColor: '#fff',
+        bodyColor: '#fff',
         callbacks: {
-          label: (ctx) => `${ctx.parsed.x} cases`,
+          label: (ctx) => {
+            const { parsed, dataset } = ctx;
+            const avg = dataset.avgRisk?.[ctx.dataIndex];
+            const doc = dataset.doctor?.[ctx.dataIndex];
+            const parts = [`${parsed.x} flags`];
+            if (avg) parts.push(`Avg Risk: ${avg}`);
+            if (doc) parts.push(`Doctor: ${doc}`);
+            return parts.join(' | ');
+          },
         },
+      },
+      datalabels: {
+        color: '#fff',
+        anchor: 'end',
+        align: 'right',
+        formatter: (val) => val,
       },
     },
     scales: {
@@ -34,7 +54,7 @@ export default function FraudMedsBarChart({ data, onSelect }) {
     },
   };
 
-  return <Bar data={data} options={options} />;
+  return <Bar data={data} options={options} style={{ backgroundColor: 'transparent' }} />;
 }
 
 FraudMedsBarChart.propTypes = {


### PR DESCRIPTION
## Summary
- add `chartjs-plugin-datalabels`
- color-code fraud bars by severity
- show data labels and richer tooltips in `FraudMedsBarChart`
- compute avg risk and top doctor for top medications
- display only top five medications

## Testing
- `npm run lint --prefix Frontend`
- `npm test --prefix Frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863da62f044832795bf4b3b0414ac81