### PR TITLE
Add fraud insights bar chart

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.10",
         "chart.js": "^4.5.0",
         "lucide-react": "^0.522.0",
+        "papaparse": "^5.5.3",
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
@@ -1508,6 +1509,60 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.10",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.10.tgz",
@@ -2951,6 +3006,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/vite": "^4.1.10",
     "chart.js": "^4.5.0",
     "lucide-react": "^0.522.0",
+    "papaparse": "^5.5.3",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",

--- a/Frontend/src/components/FraudInsightsPanel.jsx
+++ b/Frontend/src/components/FraudInsightsPanel.jsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+import Papa from 'papaparse';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+export default function FraudInsightsPanel() {
+  const [data, setData] = useState({ medications: [], doctors: [], providers: [] });
+  const [view, setView] = useState('medications');
+
+  useEffect(() => {
+    fetch('/Backend/predictions.csv')
+      .then(res => res.text())
+      .then(text => {
+        const parsed = Papa.parse(text, { header: true }).data;
+        const flagged = parsed.filter(r => r.fraud === 'True' || r.fraud === true);
+        const countTop = field => {
+          const map = {};
+          flagged.forEach(r => {
+            const key = r[field];
+            if (key) map[key] = (map[key] || 0) + 1;
+          });
+          return Object.entries(map)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 5);
+        };
+        setData({
+          medications: countTop('DESCRIPTION_med'),
+          doctors: countTop('PROVIDER'),
+          providers: countTop('ORGANIZATION'),
+        });
+      })
+      .catch(err => console.error(err));
+  }, []);
+
+  const current = data[view];
+  const chartData = {
+    labels: current.map(([name]) => name),
+    datasets: [
+      {
+        data: current.map(([, count]) => count),
+        backgroundColor: '#dc2626',
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const options = {
+    indexAxis: 'y',
+    plugins: { legend: { display: false }, tooltip: { enabled: true } },
+    scales: {
+      x: { ticks: { color: '#ffffff' }, beginAtZero: true },
+      y: { ticks: { color: '#ffffff' } },
+    },
+    animation: { duration: 500 },
+  };
+
+  const titles = {
+    medications: 'Top 5 Fraud-Flagged Medications',
+    doctors: 'Top 5 Doctors Prescribing Fraud-Flagged Meds',
+    providers: 'Top 5 Providers Dispensing Fraud-Flagged Meds',
+  };
+
+  return (
+    <div className="bg-gray-800 p-4 rounded-lg">
+      <div className="flex gap-2 mb-4">
+        {['medications', 'doctors', 'providers'].map(v => (
+          <button
+            key={v}
+            type="button"
+            onClick={() => setView(v)}
+            className={`px-2 py-1 text-xs rounded ${view === v ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-300'}`}
+          >
+            {v.charAt(0).toUpperCase() + v.slice(1)}
+          </button>
+        ))}
+      </div>
+      <h3 className="font-semibold mb-4" style={{ color: '#2F5597' }} title="Number of times each item was flagged for fraud">
+        {titles[view]}
+      </h3>
+      <Bar data={chartData} options={options} />
+    </div>
+  );
+}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
-import MedicationChart from '../components/MedicationChart';
+import FraudInsightsPanel from '../components/FraudInsightsPanel';
 import RiskTrendChart from '../components/RiskTrendChart';
 import FlaggedTable from '../components/FlaggedTable';
 
@@ -29,16 +29,6 @@ export default function Dashboard() {
   const [fraudPct, setFraudPct] = useState(0);
   const [fraudCount, setFraudCount] = useState(0);
   const [total, setTotal] = useState(0);
-  const [medChart, setMedChart] = useState({
-    labels: [],
-    datasets: [
-      {
-        data: [],
-        backgroundColor: ['#fbbf24', '#60a5fa', '#34d399', '#f472b6', '#a78bfa'],
-        borderWidth: 0,
-      },
-    ],
-  });
   const [trendChart, setTrendChart] = useState({
     labels: [],
     datasets: [
@@ -55,7 +45,6 @@ export default function Dashboard() {
   const [lastUpdated, setLastUpdated] = useState('');
   const [statusFilter, setStatusFilter] = useState('All');
   const [search, setSearch] = useState('');
-  const [medFilter, setMedFilter] = useState('');
   const [selectedRow, setSelectedRow] = useState(null);
 
   const handleBypass = async () => {
@@ -121,32 +110,7 @@ export default function Dashboard() {
           totalRecords ? Math.round((fraudRecords / totalRecords) * 100) : 0
         );
 
-        const medCounts = {};
-        data.forEach((d) => {
-          const med = d.DESCRIPTION_med;
-          if (med) {
-            medCounts[med] = (medCounts[med] || 0) + 1;
-          }
-        });
-        const sorted = Object.entries(medCounts)
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 5);
-        const labels = sorted.map(([m]) => m);
-        const counts = sorted.map(([, c]) => c);
-        setMedChart((prev) => ({
-          ...prev,
-          labels,
-          datasets: [
-            {
-              ...prev.datasets[0],
-              data: counts,
-              backgroundColor: prev.datasets[0].backgroundColor.slice(
-                0,
-                labels.length
-              ),
-            },
-          ],
-        }));
+
 
         const sortedRows = [...data]
           .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
@@ -193,12 +157,11 @@ export default function Dashboard() {
   const filteredRows = useMemo(() => {
     return rows
       .filter((r) => (statusFilter === 'All' ? true : r.status === statusFilter))
-      .filter((r) => (medFilter ? r.medication === medFilter : true))
       .filter((r) =>
         r.id.toLowerCase().includes(search.toLowerCase()) ||
         r.patient.toLowerCase().includes(search.toLowerCase())
       );
-  }, [rows, statusFilter, search, medFilter]);
+  }, [rows, statusFilter, search]);
 
   return (
     <div className="space-y-6">
@@ -241,13 +204,8 @@ export default function Dashboard() {
             </div>
           </div>
 
-          {/* Fraud Medications */}
-          <div className="bg-gray-800 p-4 rounded-lg">
-            <h3 className="font-semibold mb-4" style={{ color: '#2F5597' }}>
-              Fraud Medications
-            </h3>
-            <MedicationChart data={medChart} onSelect={(m) => setMedFilter(m)} />
-          </div>
+          {/* Fraud Insights */}
+          <FraudInsightsPanel />
 
           {/* Risk Trend */}
           <div className="bg-gray-800 p-4 rounded-lg">


### PR DESCRIPTION
## Summary
- create `FraudInsightsPanel.jsx` with toggleable bar chart views for fraud data
- integrate panel into dashboard and remove old medication chart state
- add `papaparse` dependency for CSV parsing

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863ebe851048327ae42a86cc9fb9c91