### PR TITLE
Fix provider analytics endpoint

### DIFF
--- a/Backend/analytics.py
+++ b/Backend/analytics.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter
+import pandas as pd
+from pathlib import Path
+
+analytics_router = APIRouter()
+
+PRED_FILE = Path(__file__).parent / "predictions.csv"
+
+@analytics_router.get("/top_providers")
+def top_providers():
+    """Return top 5 providers dispensing fraud-flagged meds."""
+    if not PRED_FILE.is_file():
+        return []
+    df = pd.read_csv(PRED_FILE)
+    if "likely_fraud" not in df.columns:
+        return []
+    flagged = df[df["likely_fraud"].astype(str).str.lower() == "true"]
+    if flagged.empty:
+        return []
+    counts = (
+        flagged.groupby("ORGANIZATION")
+        .size()
+        .reset_index(name="count")
+        .sort_values("count", ascending=False)
+        .head(5)
+    )
+    return [
+        {"Provider_med": row["ORGANIZATION"], "count": int(row["count"])}
+        for _, row in counts.iterrows()
+    ]

--- a/Backend/app.py
+++ b/Backend/app.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from auth import auth_router
 from model_predict import model_router
 from users import user_router
+from analytics import analytics_router
 
 app = FastAPI()
 
@@ -22,3 +23,4 @@ def root():
 app.include_router(auth_router, prefix="/auth")
 app.include_router(model_router, prefix="/predict")
 app.include_router(user_router, prefix="/user")
+app.include_router(analytics_router, prefix="/analytics")


### PR DESCRIPTION
## Summary
- implement `analytics.py` with `/top_providers` endpoint for FastAPI
- wire analytics router in `app.py`
- fetch provider analytics in `FraudInsightsPanel` and source other data from history endpoint

## Testing
- `python -m py_compile Backend/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863ee3709b08327a52b6d1472d6f743