### PR TITLE
Add BypassTimeline visualization

### DIFF
--- a/Backend/model_predict.py
+++ b/Backend/model_predict.py
@@ -177,3 +177,27 @@ def bypass_patient(data: BypassInput):
     with open(WHITELIST_FILE, "w") as f:
         json.dump(sorted(RARE_CASE_PATIENTS), f)
     return {"message": f"{pid} added to whitelist"}
+
+
+@model_router.get("/bypass-history")
+def bypass_history():
+    """Return records manually bypassed due to rare conditions."""
+    if not PRED_FILE.is_file():
+        return []
+    events = []
+    with open(PRED_FILE, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            flags = row.get("flags", "")
+            if "rare" in flags.lower():
+                events.append(
+                    {
+                        "timestamp": row.get("timestamp"),
+                        "PATIENT_med": row.get("PATIENT_med"),
+                        "PROVIDER": row.get("PROVIDER"),
+                        "DESCRIPTION_med": row.get("DESCRIPTION_med"),
+                        "flags": flags,
+                        "status": "RARE",
+                    }
+                )
+    return events

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.10",
         "chart.js": "^4.5.0",
+        "chartjs-adapter-date-fns": "^3.0.0",
         "lucide-react": "^0.522.0",
         "papaparse": "^5.5.3",
         "prop-types": "^15.8.1",
@@ -1882,6 +1883,16 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -1955,6 +1966,17 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
     "chart.js": "^4.5.0",
+    "chartjs-adapter-date-fns": "^3.0.0",
     "lucide-react": "^0.522.0",
     "papaparse": "^5.5.3",
     "prop-types": "^15.8.1",

--- a/Frontend/src/components/BypassTimeline.jsx
+++ b/Frontend/src/components/BypassTimeline.jsx
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types';
+import { useState, useMemo } from 'react';
+import { Scatter } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  TimeScale,
+} from 'chart.js';
+import 'chartjs-adapter-date-fns';
+
+ChartJS.register(LinearScale, PointElement, Tooltip, TimeScale);
+
+export default function BypassTimeline({ data }) {
+  const [range, setRange] = useState('30');
+
+  const filtered = useMemo(() => {
+    if (range === 'all') return data;
+    const days = Number(range);
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    return data.filter((d) => new Date(d.timestamp) >= cutoff);
+  }, [data, range]);
+
+  const chartData = useMemo(
+    () => ({
+      datasets: [
+        {
+          label: 'Bypassed',
+          data: filtered.map((d) => ({ x: d.timestamp, y: 1 })),
+          pointBackgroundColor: '#f1c40f',
+          pointBorderColor: '#f1c40f',
+          pointRadius: 6,
+        },
+      ],
+    }),
+    [filtered]
+  );
+
+  const options = {
+    scales: {
+      x: {
+        type: 'time',
+        ticks: { color: '#ffffff' },
+        grid: { color: '#333' },
+      },
+      y: { display: false },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label(ctx) {
+            const item = filtered[ctx.dataIndex];
+            return `${item.DESCRIPTION_med} (Patient ${item.PATIENT_med}) - ${item.PROVIDER} [RARE]`;
+          },
+        },
+      },
+    },
+    responsive: true,
+    maintainAspectRatio: false,
+  };
+
+  return (
+    <div className="bg-gray-800 p-4 rounded-lg">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="font-semibold" style={{ color: '#2F5597' }}>
+          Recent Bypassed Fraud Records
+        </h3>
+        <select
+          className="bg-gray-700 text-sm p-1 rounded"
+          value={range}
+          onChange={(e) => setRange(e.target.value)}
+        >
+          <option value="7">Last 7 days</option>
+          <option value="30">Last 30 days</option>
+          <option value="90">Last 90 days</option>
+          <option value="all">All time</option>
+        </select>
+      </div>
+      {filtered.length === 0 ? (
+        <p className="text-center text-gray-400">No recent bypass activity</p>
+      ) : (
+        <div className="h-64">
+          <Scatter data={chartData} options={options} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+BypassTimeline.propTypes = {
+  data: PropTypes.array.isRequired,
+};

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -13,6 +13,7 @@ import {
 import FraudInsightsPanel from '../components/FraudInsightsPanel';
 import RiskTrendChart from '../components/RiskTrendChart';
 import FlaggedTable from '../components/FlaggedTable';
+import BypassTimeline from '../components/BypassTimeline';
 
 ChartJS.register(
   ArcElement,
@@ -46,6 +47,7 @@ export default function Dashboard() {
   const [statusFilter, setStatusFilter] = useState('All');
   const [search, setSearch] = useState('');
   const [selectedRow, setSelectedRow] = useState(null);
+  const [bypassHistory, setBypassHistory] = useState([]);
 
   const handleBypass = async () => {
     if (!selectedRow) return;
@@ -132,6 +134,13 @@ export default function Dashboard() {
         }));
         setLastUpdated(new Date().toLocaleString());
       })
+      .catch((err) => console.error(err));
+  }, []);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/predict/bypass-history')
+      .then((res) => res.json())
+      .then((items) => setBypassHistory(items))
       .catch((err) => console.error(err));
   }, []);
 
@@ -229,6 +238,7 @@ export default function Dashboard() {
             onSearchChange={setSearch}
             onReview={(r) => setSelectedRow(r)}
           />
+          <BypassTimeline data={bypassHistory} />
         </div>
       </div>
       <button

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Route                     Description
 POST /auth/login          Login (email + password)
 POST /predict             Fraud prediction via ML model
 GET /user/...             (Optional) User routes
+GET /predict/bypass-history  Recently bypassed rare cases
 
 💡 Features
 ✅ Rule-based + ML medication risk classification


### PR DESCRIPTION
## Summary
- implement `/predict/bypass-history` endpoint in backend
- visualize bypassed prescriptions with new `BypassTimeline` React component
- show timeline on dashboard and fetch bypass events
- add chartjs time adapter dependency
- document new API route

## Testing
- `npm run lint`
- `python -m py_compile *.py`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6863ff1397d08327993e510d93dde9bf