### PR TITLE
Add bypass logging support

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -24,3 +24,38 @@ app.include_router(auth_router, prefix="/auth")
 app.include_router(model_router, prefix="/predict")
 app.include_router(user_router, prefix="/user")
 app.include_router(analytics_router, prefix="/analytics")
+
+
+@app.post("/bypass")
+def bypass_prescription(entry: dict):
+    """Logs a bypassed prescription to bypass_log.csv"""
+    import pandas as pd
+    from pathlib import Path
+    from datetime import datetime
+
+    entry["timestamp"] = datetime.now().isoformat()
+
+    bypass_file = Path(__file__).parent / "bypass_log.csv"
+
+    df_new = pd.DataFrame([entry])
+    if bypass_file.is_file():
+        df_new.to_csv(bypass_file, mode="a", header=False, index=False)
+    else:
+        df_new.to_csv(bypass_file, mode="w", header=True, index=False)
+
+    return {"message": "Bypass logged"}
+
+
+@app.get("/bypass-logs")
+def get_bypass_logs():
+    """Return logged bypassed prescriptions sorted by most recent."""
+    import pandas as pd
+    from pathlib import Path
+
+    bypass_file = Path(__file__).parent / "bypass_log.csv"
+    if not bypass_file.is_file():
+        return []
+    df = pd.read_csv(bypass_file)
+    if "timestamp" in df.columns:
+        df = df.sort_values("timestamp", ascending=False)
+    return df.to_dict(orient="records")

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -52,19 +52,27 @@ export default function Dashboard() {
   const handleBypass = async () => {
     if (!selectedRow) return;
     try {
-      const res = await fetch('http://localhost:8000/predict/bypass', {
+      await fetch('http://localhost:8000/bypass', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ patient_id: selectedRow.patient }),
+        body: JSON.stringify({
+          rx_id: selectedRow.id,
+          patient: selectedRow.patient,
+          doctor: selectedRow.doctor,
+          medication: selectedRow.medication,
+          status: selectedRow.status,
+        }),
       });
-      if (res.ok) {
-        setRows((prev) =>
-          prev.map((r) =>
-            r.id === selectedRow.id ? { ...r, rare: true, status: 'Cleared' } : r
-          )
-        );
-        setSelectedRow(null);
-      }
+      setRows((prev) =>
+        prev.map((r) =>
+          r.id === selectedRow.id ? { ...r, status: 'Cleared' } : r
+        )
+      );
+      setSelectedRow(null);
+      fetch('http://localhost:8000/bypass-logs')
+        .then((res) => res.json())
+        .then((items) => setBypassHistory(items))
+        .catch((err) => console.error(err));
     } catch (err) {
       console.error(err);
     }
@@ -138,7 +146,7 @@ export default function Dashboard() {
   }, []);
 
   useEffect(() => {
-    fetch('http://localhost:8000/predict/bypass-history')
+    fetch('http://localhost:8000/bypass-logs')
       .then((res) => res.json())
       .then((items) => setBypassHistory(items))
       .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- log bypass events in `bypass_log.csv`
- expose `/bypass` and `/bypass-logs` endpoints
- update dashboard to post bypass info and display latest bypasses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m pip install -r Backend/requirements.txt`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686407a353208327995c2bc16477c158