### PR TITLE
Fix bypass timeline fetching from CSV

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -49,15 +49,43 @@ def bypass_prescription(entry: dict):
 
 
 @app.get("/bypass-logs")
-def get_bypass_logs():
-    """Return logged bypassed prescriptions sorted by most recent."""
+def get_bypass_logs(days: int | None = None):
+    """Return logged bypassed prescriptions sorted by most recent.
+
+    Parameters
+    ----------
+    days: int | None
+        Optional number of days back to include. If provided, only records
+        with a timestamp within the last `days` days will be returned.
+    """
     import pandas as pd
     from pathlib import Path
 
     bypass_file = Path(__file__).parent / "bypass_log.csv"
     if not bypass_file.is_file():
         return []
+
     df = pd.read_csv(bypass_file)
+
+    # Normalise column names so the frontend has a consistent structure
+    column_map = {
+        "prescription_id": "rx_id",
+        "patient_name": "patient",
+        "doctor_name": "doctor",
+        "medication_name": "medication",
+        "date": "timestamp",
+    }
+    for src, dest in column_map.items():
+        if src in df.columns and dest not in df.columns:
+            df[dest] = df[src]
+
+    if "timestamp" not in df.columns and "date" in df.columns:
+        df["timestamp"] = df["date"]
+
     if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
         df = df.sort_values("timestamp", ascending=False)
+        if days is not None:
+            cutoff = pd.Timestamp.now() - pd.Timedelta(days=days)
+            df = df[df["timestamp"] >= cutoff]
     return df.to_dict(orient="records")

--- a/Frontend/src/components/BypassTimelineLog.jsx
+++ b/Frontend/src/components/BypassTimelineLog.jsx
@@ -1,21 +1,29 @@
-import PropTypes from 'prop-types';
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { format } from 'date-fns';
 
-export default function BypassTimelineLog({ data }) {
+export default function BypassTimelineLog() {
   const [range, setRange] = useState('30');
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const url =
+      range === 'all'
+        ? 'http://localhost:8000/bypass-logs'
+        : `http://localhost:8000/bypass-logs?days=${range}`;
+    fetch(url)
+      .then((res) => res.json())
+      .then((items) => setData(items))
+      .catch((err) => console.error(err));
+  }, [range]);
 
   const filtered = useMemo(() => {
-    let records = data.filter((d) => d.status === 'RARE');
+    let records = data.filter((d) =>
+      (d.status || '').toLowerCase().includes('bypass') ||
+      (d.status || '').toLowerCase() === 'rare'
+    );
     records = records.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-    if (range !== 'all') {
-      const days = Number(range);
-      const cutoff = new Date();
-      cutoff.setDate(cutoff.getDate() - days);
-      records = records.filter((d) => new Date(d.timestamp) >= cutoff);
-    }
     return records;
-  }, [data, range]);
+  }, [data]);
 
   return (
     <div className="bg-gray-800 p-4 rounded-lg">
@@ -65,6 +73,3 @@ export default function BypassTimelineLog({ data }) {
   );
 }
 
-BypassTimelineLog.propTypes = {
-  data: PropTypes.array.isRequired,
-};

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -47,7 +47,6 @@ export default function Dashboard() {
   const [statusFilter, setStatusFilter] = useState('All');
   const [search, setSearch] = useState('');
   const [selectedRow, setSelectedRow] = useState(null);
-  const [bypassHistory, setBypassHistory] = useState([]);
 
   const handleBypass = async () => {
     if (!selectedRow) return;
@@ -69,10 +68,6 @@ export default function Dashboard() {
         )
       );
       setSelectedRow(null);
-      fetch('http://localhost:8000/bypass-logs')
-        .then((res) => res.json())
-        .then((items) => setBypassHistory(items))
-        .catch((err) => console.error(err));
     } catch (err) {
       console.error(err);
     }
@@ -145,12 +140,6 @@ export default function Dashboard() {
       .catch((err) => console.error(err));
   }, []);
 
-  useEffect(() => {
-    fetch('http://localhost:8000/bypass-logs')
-      .then((res) => res.json())
-      .then((items) => setBypassHistory(items))
-      .catch((err) => console.error(err));
-  }, []);
 
   const donutFraudData = {
     labels: ['Fraud', 'Other'],
@@ -246,7 +235,7 @@ export default function Dashboard() {
             onSearchChange={setSearch}
             onReview={(r) => setSelectedRow(r)}
           />
-          <BypassTimelineLog data={bypassHistory} />
+          <BypassTimelineLog />
         </div>
       </div>
       <button


### PR DESCRIPTION
## Summary
- normalize bypass log fields on backend
- add optional `days` filtering
- load bypass timeline directly from `/bypass-logs` using selected range
- remove unused state from dashboard

## Testing
- `npm run lint`
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6864141de0948327a0278bc8039e3ad7