### PR TITLE
Fix bypass logs filtering in dashboard

### DIFF
--- a/Frontend/src/components/BypassTimelineLog.jsx
+++ b/Frontend/src/components/BypassTimelineLog.jsx
@@ -1,21 +1,28 @@
-import PropTypes from 'prop-types';
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { format } from 'date-fns';
 
-export default function BypassTimelineLog({ data }) {
+export default function BypassTimelineLog() {
   const [range, setRange] = useState('30');
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const url =
+      range === 'all'
+        ? 'http://localhost:8000/bypass-logs'
+        : `http://localhost:8000/bypass-logs?days=${range}`;
+    fetch(url)
+      .then((res) => res.json())
+      .then((items) => setData(items))
+      .catch((err) => console.error(err));
+  }, [range]);
 
   const filtered = useMemo(() => {
-    let records = data.filter((d) => d.status === 'RARE');
+    let records = data.filter(
+      (d) => (d.status || '').toLowerCase().includes('bypass') || (d.status || '').toLowerCase() === 'rare'
+    );
     records = records.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-    if (range !== 'all') {
-      const days = Number(range);
-      const cutoff = new Date();
-      cutoff.setDate(cutoff.getDate() - days);
-      records = records.filter((d) => new Date(d.timestamp) >= cutoff);
-    }
     return records;
-  }, [data, range]);
+  }, [data]);
 
   return (
     <div className="bg-gray-800 p-4 rounded-lg">
@@ -65,6 +72,3 @@ export default function BypassTimelineLog({ data }) {
   );
 }
 
-BypassTimelineLog.propTypes = {
-  data: PropTypes.array.isRequired,
-};

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -47,7 +47,6 @@ export default function Dashboard() {
   const [statusFilter, setStatusFilter] = useState('All');
   const [search, setSearch] = useState('');
   const [selectedRow, setSelectedRow] = useState(null);
-  const [bypassHistory, setBypassHistory] = useState([]);
 
   const handleBypass = async () => {
     if (!selectedRow) return;
@@ -69,10 +68,6 @@ export default function Dashboard() {
         )
       );
       setSelectedRow(null);
-      fetch('http://localhost:8000/bypass-logs')
-        .then((res) => res.json())
-        .then((items) => setBypassHistory(items))
-        .catch((err) => console.error(err));
     } catch (err) {
       console.error(err);
     }
@@ -142,13 +137,6 @@ export default function Dashboard() {
         }));
         setLastUpdated(new Date().toLocaleString());
       })
-      .catch((err) => console.error(err));
-  }, []);
-
-  useEffect(() => {
-    fetch('http://localhost:8000/bypass-logs')
-      .then((res) => res.json())
-      .then((items) => setBypassHistory(items))
       .catch((err) => console.error(err));
   }, []);
 
@@ -246,7 +234,7 @@ export default function Dashboard() {
             onSearchChange={setSearch}
             onReview={(r) => setSelectedRow(r)}
           />
-          <BypassTimelineLog data={bypassHistory} />
+          <BypassTimelineLog />
         </div>
       </div>
       <button


### PR DESCRIPTION
## Summary
- enhance `/bypass-logs` endpoint with column normalization and optional `days` filtering
- make `BypassTimelineLog` fetch its own data using selected time range
- simplify dashboard by removing unused bypass state

## Testing
- `python -m py_compile Backend/app.py`
- `python -m py_compile Backend/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686419f0117c8327b0d080c0a3d6e2f0