### PR TITLE
Add bypass logging endpoint

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from auth import auth_router
 from model_predict import model_router
 from users import user_router
+from bypass import bypass_router
 
 app = FastAPI()
 
@@ -22,3 +23,4 @@ def root():
 app.include_router(auth_router, prefix="/auth")
 app.include_router(model_router, prefix="/predict")
 app.include_router(user_router, prefix="/user")
+app.include_router(bypass_router, prefix="/bypass")

--- a/Backend/bypass.py
+++ b/Backend/bypass.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from pathlib import Path
+from datetime import datetime
+import csv
+
+bypass_router = APIRouter()
+
+LOG_FILE = Path(__file__).parent / "bypass_log.csv"
+FIELDNAMES = ["rx_id", "patient", "doctor", "medication", "status", "timestamp"]
+
+class BypassEntry(BaseModel):
+    rx_id: str
+    patient: str
+    doctor: str
+    medication: str
+    status: str
+
+@bypass_router.post("")
+def log_bypass(entry: BypassEntry):
+    record = entry.dict()
+    record["timestamp"] = datetime.utcnow().isoformat()
+    try:
+        file_exists = LOG_FILE.is_file()
+        with open(LOG_FILE, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(record)
+    except OSError:
+        raise HTTPException(status_code=500, detail="Could not write to log file")
+    return {"detail": "bypass logged"}
+
+@bypass_router.get("/history")
+def get_bypass_history():
+    if not LOG_FILE.is_file():
+        return []
+    try:
+        with open(LOG_FILE, newline="") as f:
+            reader = csv.DictReader(f, fieldnames=FIELDNAMES)
+            return list(reader)
+    except OSError:
+        raise HTTPException(status_code=500, detail="Could not read log file")


### PR DESCRIPTION
## Summary
- implement `bypass.py` with `POST /bypass` and `GET /bypass/history`
- register new bypass router in the FastAPI app

## Testing
- `python3 -m py_compile Backend/bypass.py Backend/app.py Backend/model_predict.py Backend/auth.py Backend/users.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864229d7bc88327b567fe4a5806a520