### PR TITLE
Add bypass logging route

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -4,6 +4,7 @@ from auth import auth_router
 from model_predict import model_router
 from users import user_router
 from analytics import analytics_router
+from bypass_logger import bypass_router
 
 app = FastAPI()
 
@@ -24,3 +25,4 @@ app.include_router(auth_router, prefix="/auth")
 app.include_router(model_router, prefix="/predict")
 app.include_router(user_router, prefix="/user")
 app.include_router(analytics_router, prefix="/analytics")
+app.include_router(bypass_router, prefix="/bypass")

--- a/Backend/bypass_logger.py
+++ b/Backend/bypass_logger.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from pathlib import Path
+from datetime import datetime
+import csv
+
+bypass_router = APIRouter()
+
+LOG_FILE = Path(__file__).parent / "bypass_log.csv"
+FIELDNAMES = ["rx_id", "patient", "doctor", "medication", "status", "timestamp"]
+
+
+class BypassEntry(BaseModel):
+    rx_id: str
+    patient: str
+    doctor: str
+    medication: str
+    status: str
+
+
+@bypass_router.post("/")
+def log_bypass(entry: BypassEntry):
+    """Log a bypass action for audit purposes."""
+    record = entry.dict()
+    record["timestamp"] = datetime.utcnow().isoformat()
+
+    try:
+        file_exists = LOG_FILE.is_file()
+        with open(LOG_FILE, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+            if not file_exists or LOG_FILE.stat().st_size == 0:
+                writer.writeheader()
+            writer.writerow(record)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to log bypass: {e}")
+
+    return {"message": "Bypass logged"}


### PR DESCRIPTION
## Summary
- handle bypass POST requests in the backend
- register bypass router in the FastAPI app

## Testing
- `python -m py_compile Backend/bypass_logger.py Backend/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686423e293248327964a206f5f0338cb