### PR TITLE
Fix fraud feed error when FRAUD_TYPE missing

### DIFF
--- a/Frontend/src/components/MiniFraudFeed.jsx
+++ b/Frontend/src/components/MiniFraudFeed.jsx
@@ -51,9 +51,9 @@ export default function MiniFraudFeed() {
     });
   };
 
-  const fraudColor = type => {
-    if (type.includes('Duplicate')) return 'bg-red-600';
-    if (type.includes('Rare')) return 'bg-yellow-500';
+  const fraudColor = (type = '') => {
+    if (type?.includes('Duplicate')) return 'bg-red-600';
+    if (type?.includes('Rare')) return 'bg-yellow-500';
     return 'bg-orange-500';
   };
 
@@ -76,7 +76,7 @@ export default function MiniFraudFeed() {
               item.FRAUD_TYPE,
             )}`}
           >
-            {item.FRAUD_TYPE}
+            {item.FRAUD_TYPE || 'Unknown'}
           </span>
           <div className="mt-2 text-sm">
             <span className="mr-1">👨‍⚕️</span>


### PR DESCRIPTION
## Summary
- handle undefined `FRAUD_TYPE` values when assigning colors
- show fallback label if fraud type is not provided

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68644ba3cadc8327b299991a3721fd98