### PR TITLE
Use flag status in fraud feed

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.10",
         "axios": "^1.6.8",
         "chart.js": "^4.5.0",
+        "dayjs": "^1.11.13",
         "lucide-react": "^0.522.0",
         "papaparse": "^5.5.3",
         "prop-types": "^15.8.1",
@@ -1997,6 +1998,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
+    "axios": "^1.6.8",
     "chart.js": "^4.5.0",
+    "dayjs": "^1.11.13",
     "lucide-react": "^0.522.0",
     "papaparse": "^5.5.3",
     "prop-types": "^15.8.1",
@@ -20,8 +22,7 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2",
-    "tailwindcss": "^4.1.10",
-    "axios": "^1.6.8"
+    "tailwindcss": "^4.1.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/Frontend/src/components/MiniFraudFeed.jsx
+++ b/Frontend/src/components/MiniFraudFeed.jsx
@@ -1,5 +1,9 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
 
 export default function MiniFraudFeed() {
   const [items, setItems] = useState([]);
@@ -42,19 +46,19 @@ export default function MiniFraudFeed() {
     return <div className="text-red-500">{error}</div>;
   }
 
-  const formatDate = ts => {
-    const date = new Date(ts);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: '2-digit',
-      year: 'numeric',
-    });
-  };
+  const formatDate = ts => dayjs(ts).fromNow();
 
   const fraudColor = (type = '') => {
     if (type?.includes('Duplicate')) return 'bg-red-600';
     if (type?.includes('Rare')) return 'bg-yellow-500';
     return 'bg-orange-500';
+  };
+
+  const flagColor = (status = '') => {
+    if (status === 'Flagged') return 'bg-red-600';
+    if (status === 'Cleared') return 'bg-green-500';
+    if (status === 'Rare' || status === 'Rare condition') return 'bg-yellow-600';
+    return 'bg-gray-500';
   };
 
   const scoreColor = score => {
@@ -77,6 +81,13 @@ export default function MiniFraudFeed() {
             )}`}
           >
             {item.FRAUD_TYPE || 'Unknown'}
+          </span>
+          <span
+            className={`ml-2 text-xs px-2 py-1 rounded ${flagColor(
+              item.flag_status,
+            )}`}
+          >
+            {item.flag_status?.trim() ? item.flag_status : 'Unknown'}
           </span>
           <div className="mt-2 text-sm">
             <span className="mr-1">👨‍⚕️</span>


### PR DESCRIPTION
## Summary
- show prediction time using `dayjs` relative time
- display flag status from API
- style flag status pill with same colors as other status pills
- add `dayjs` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68663997d154832796722db3db28776e