### PR TITLE
Update fraud case badge logic

### DIFF
--- a/Frontend/src/components/StatusBadge.jsx
+++ b/Frontend/src/components/StatusBadge.jsx
@@ -1,0 +1,13 @@
+export default function StatusBadge({ flag_status }) {
+  if (!flag_status) return null;
+  const status = flag_status.trim();
+  const classes = {
+    Flagged: 'bg-red-600',
+    Cleared: 'bg-green-600',
+    RARE: 'bg-yellow-400 text-black',
+  };
+  if (!classes[status]) return null;
+  return (
+    <span className={`inline-block px-2 py-1 rounded text-xs font-medium ${classes[status]}`}>{status}</span>
+  );
+}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ import {
   Legend,
 } from 'chart.js';
 import { Star, AlertTriangle } from 'lucide-react';
+import StatusBadge from '../components/StatusBadge.jsx';
 
 ChartJS.register(
   ArcElement,
@@ -59,7 +60,7 @@ export default function Dashboard() {
           data.map((r, i) => ({
             id: `RX${String(i + 1).padStart(3, '0')}`,
             patient: r.PATIENT_med,
-            status: r.fraud === 'True' || r.fraud === true ? 'Flagged' : 'Cleared',
+            flag_status: r.fraud === 'True' || r.fraud === true ? 'Flagged' : 'Cleared',
             risk: Math.min(5, Math.round(Number(r.risk_score) / 20)),
             doctor: r.PROVIDER,
           }))
@@ -253,9 +254,7 @@ export default function Dashboard() {
                     <td className="py-2 font-medium">{row.id}</td>
                     <td className="py-2">{row.patient}</td>
                     <td className="py-2">
-                      <span className={row.status === 'Flagged' ? 'text-red-500' : 'text-green-500'}>
-                        {row.status}
-                      </span>
+                      <StatusBadge flag_status={row.flag_status} />
                     </td>
                     <td className="py-2">
                       {Array.from({ length: 5 }).map((_, i) => (
@@ -266,7 +265,7 @@ export default function Dashboard() {
                       ))}
                     </td>
                     <td className="py-2">
-                      {row.status === 'Flagged' && (
+                      {row.flag_status === 'Flagged' && (
                         <AlertTriangle className="text-red-600 w-5 h-5" />
                       )}
                     </td>

--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ArrowUpRight, AlertTriangle, UserCircle, Star } from 'lucide-react';
+import StatusBadge from '../components/StatusBadge.jsx';
 import { Doughnut, Line } from 'react-chartjs-2';
 import { Chart as ChartJS, ArcElement, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from 'chart.js';
 
@@ -66,7 +67,7 @@ export default function Home() {
           data.map((r, i) => ({
             id: `RX${String(i + 1).padStart(3, '0')}`,
             patient: r.PATIENT_med,
-            status: r.fraud === 'True' ? 'Flagged' : 'Cleared',
+            flag_status: r.fraud === 'True' ? 'Flagged' : 'Cleared',
             risk: Math.min(5, Math.round(Number(r.risk_score) / 20)),
             doctor: r.PROVIDER,
           }))
@@ -180,9 +181,7 @@ export default function Home() {
                 <td className="py-2 font-medium">{row.id}</td>
                 <td className="py-2">{row.patient}</td>
                 <td className="py-2">
-                  <span className={row.status === 'Flagged' ? 'text-red-600' : 'text-green-600'}>
-                    {row.status}
-                  </span>
+                  <StatusBadge flag_status={row.flag_status} />
                 </td>
                 <td className="py-2">
                   {Array.from({ length: 5 }).map((_, i) => (
@@ -190,7 +189,9 @@ export default function Home() {
                   ))}
                 </td>
                 <td className="py-2">
-                  {row.status === 'Flagged' && <AlertTriangle className="text-red-600 w-5 h-5" />}
+                  {row.flag_status === 'Flagged' && (
+                    <AlertTriangle className="text-red-600 w-5 h-5" />
+                  )}
                 </td>
                 <td className="py-2 flex items-center gap-1">
                   <UserCircle className="w-5 h-5 text-gray-400" /> {row.doctor}


### PR DESCRIPTION
## Summary
- add reusable `StatusBadge` component
- show status badges in dashboard and home pages
- only display badge when flag_status is `Flagged`, `Cleared` or `RARE`
- cleanup old status rendering logic

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68663cd11c108327912b000b1e48f60d