### PR TITLE
Enhance fraud card status and timestamp

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.10",
         "axios": "^1.6.8",
         "chart.js": "^4.5.0",
+        "dayjs": "1.11.13",
         "lucide-react": "^0.522.0",
         "papaparse": "^5.5.3",
         "prop-types": "^15.8.1",
@@ -1997,6 +1998,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
+    "axios": "^1.6.8",
     "chart.js": "^4.5.0",
+    "dayjs": "1.11.13",
     "lucide-react": "^0.522.0",
     "papaparse": "^5.5.3",
     "prop-types": "^15.8.1",
@@ -20,8 +22,7 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2",
-    "tailwindcss": "^4.1.10",
-    "axios": "^1.6.8"
+    "tailwindcss": "^4.1.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/Frontend/src/components/MiniFraudFeed.jsx
+++ b/Frontend/src/components/MiniFraudFeed.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+import dayjs from 'dayjs';
 
 export default function MiniFraudFeed() {
   const [items, setItems] = useState([]);
@@ -42,14 +43,7 @@ export default function MiniFraudFeed() {
     return <div className="text-red-500">{error}</div>;
   }
 
-  const formatDate = ts => {
-    const date = new Date(ts);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: '2-digit',
-      year: 'numeric',
-    });
-  };
+  const formatDate = ts => dayjs(ts).format('MMM DD, YYYY, h:mm A');
 
   const fraudColor = (type = '') => {
     if (type?.includes('Duplicate')) return 'bg-red-600';
@@ -81,6 +75,19 @@ export default function MiniFraudFeed() {
           <div className="mt-2 text-sm">
             <span className="mr-1">👨‍⚕️</span>
             {item.PROVIDER} - {item.ORGANIZATION}
+          </div>
+          <div className="mt-1">
+            <span
+              className={`px-2 py-1 text-xs rounded ${
+                !item.flag_status || item.flag_status === 'Unknown'
+                  ? 'bg-red-600 text-white'
+                  : 'bg-gray-600 text-white'
+              }`}
+            >
+              {!item.flag_status || item.flag_status === 'Unknown'
+                ? 'Flagged'
+                : item.flag_status}
+            </span>
           </div>
           <div className="text-xs mt-1">
             🕒 {formatDate(item.timestamp || item.prediction_time)}


### PR DESCRIPTION
## Summary
- show formatted prediction time with dayjs
- add flag_status badge and style flagged status in red
- install `dayjs` for date formatting

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866463d4cf8832795809b74a6f48c50