### PR TITLE
Add chart heading in Home page

### DIFF
--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -191,6 +191,9 @@ export default function Home() {
 
       {/* Fraud Trends */}
       <div className="bg-gray-800 p-6 rounded-lg shadow">
+        <h3 className="text-2xl font-semibold text-white text-center mt-6 mb-4">
+          Fraud Risk Score Trend
+        </h3>
 
         <Plot
           data={[


### PR DESCRIPTION
## Summary
- show a heading above the rolling average chart to label it "Fraud Risk Score Trend"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bcf90bfa0832788feb4048539ce3b