### PR TITLE
Improve review notes display

### DIFF
--- a/Backend/prescription_api.py
+++ b/Backend/prescription_api.py
@@ -24,12 +24,13 @@ def get_prescription(rx_id: str):
             raise HTTPException(status_code=404, detail="Prescription not found")
         row = reader[idx]
 
-    # Basic example fields; extend as needed
+    # Gather relevant details for the prescription
     details = {
         "id": rx_id,
         "patient": row.get("PATIENT_med"),
         "doctor": row.get("PROVIDER"),
-        "notes": "Follow up in 2 weeks.",
-        "doctor_comments": row.get("flags") or "No comments",
+        "medication": row.get("DESCRIPTION_med"),
+        # Combine any doctor provided notes or comments under one field
+        "notes": row.get("flags") or "No notes",
     }
     return details

--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -326,10 +326,12 @@ export default function Home() {
                       ) : (
                         <>
                           <p>
-                            <strong>Notes:</strong> {details[row.id]?.notes || 'N/A'}
+                            <strong>Medication:</strong>{' '}
+                            {details[row.id]?.medication || 'N/A'}
                           </p>
                           <p>
-                            <strong>Doctor Comments:</strong> {details[row.id]?.doctor_comments || 'N/A'}
+                            <strong>Notes:</strong>{' '}
+                            {details[row.id]?.notes || 'N/A'}
                           </p>
                         </>
                       )}


### PR DESCRIPTION
## Summary
- add medication and notes fields to `/prescription/{rx_id}` API
- show medication name and notes when a row is expanded in `Home` page

## Testing
- `npm install`
- `npm run lint`
- `python -m py_compile Backend/prescription_api.py`


------
https://chatgpt.com/codex/tasks/task_e_686be9a112488327829570c3373673b9