### PR TITLE
Add live outcome donut chart

### DIFF
--- a/Backend/model_predict.py
+++ b/Backend/model_predict.py
@@ -177,3 +177,24 @@ def bypass_patient(data: BypassInput):
     with open(WHITELIST_FILE, "w") as f:
         json.dump(sorted(RARE_CASE_PATIENTS), f)
     return {"message": f"{pid} added to whitelist"}
+
+
+@model_router.get("/summary")
+def get_outcome_summary():
+    """Return counts of fraud, cleared, and rare prescriptions."""
+    fraud = 0
+    cleared = 0
+    rare = 0
+    if PRED_FILE.is_file():
+        with open(PRED_FILE, newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                is_fraud = str(row.get("fraud", "")).lower() == "true"
+                flags = str(row.get("flags", "")).lower()
+                if is_fraud:
+                    fraud += 1
+                else:
+                    cleared += 1
+                if "rare condition" in flags:
+                    rare += 1
+    return {"fraud": fraud, "cleared": cleared, "rare": rare}

--- a/Frontend/src/components/OutcomeDonut.jsx
+++ b/Frontend/src/components/OutcomeDonut.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { Doughnut } from 'react-chartjs-2';
+
+export default function OutcomeDonut() {
+  const [counts, setCounts] = useState({ fraud: 0, cleared: 0, rare: 0 });
+  const [lastUpdated, setLastUpdated] = useState('');
+
+  useEffect(() => {
+    const fetchData = () => {
+      fetch('http://localhost:8000/predict/summary')
+        .then((res) => res.json())
+        .then((data) => {
+          setCounts(data);
+          setLastUpdated(new Date().toLocaleTimeString());
+        })
+        .catch((err) => console.error(err));
+    };
+
+    fetchData();
+    const id = setInterval(fetchData, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  const total = counts.fraud + counts.cleared + counts.rare;
+
+  const chartData = {
+    labels: ['Fraud', 'Cleared', 'Rare'],
+    datasets: [
+      {
+        data: [counts.fraud, counts.cleared, counts.rare],
+        backgroundColor: ['#dc2626', '#16a34a', '#eab308'],
+        borderWidth: 0,
+      },
+    ],
+  };
+
+  const options = {
+    plugins: { legend: { display: false } },
+    cutout: '70%',
+    animation: { duration: 500 },
+  };
+
+  const pct = (val) => (total ? Math.round((val / total) * 100) : 0);
+
+  return (
+    <div className="text-white text-center">
+      <div className="relative w-20 h-20 mx-auto">
+        <Doughnut data={chartData} options={options} />
+        <div className="absolute inset-0 flex items-center justify-center text-xs">
+          Total: {total}
+        </div>
+      </div>
+      <ul className="mt-2 space-y-1 text-xs">
+        <li className="flex items-center justify-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: '#dc2626' }}></span>
+          Fraud: {counts.fraud} ({pct(counts.fraud)}%)
+        </li>
+        <li className="flex items-center justify-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: '#16a34a' }}></span>
+          Cleared: {counts.cleared} ({pct(counts.cleared)}%)
+        </li>
+        <li className="flex items-center justify-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: '#eab308' }}></span>
+          Rare: {counts.rare} ({pct(counts.rare)}%)
+        </li>
+      </ul>
+      {lastUpdated && (
+        <p className="text-gray-400 text-xs mt-1">Last Updated: {lastUpdated}</p>
+      )}
+    </div>
+  );
+}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -13,6 +13,7 @@ import {
 import FraudInsightsPanel from '../components/FraudInsightsPanel';
 import RiskTrendChart from '../components/RiskTrendChart';
 import FlaggedTable from '../components/FlaggedTable';
+import OutcomeDonut from '../components/OutcomeDonut';
 
 ChartJS.register(
   ArcElement,
@@ -147,12 +148,6 @@ export default function Dashboard() {
       { data: [fraudPct, 100 - fraudPct], backgroundColor: ['#0ea5e9', '#e5e7eb'], borderWidth: 0 },
     ],
   };
-  const donutTotalData = {
-    labels: ['Total'],
-    datasets: [
-      { data: [100, 0], backgroundColor: ['#2dd4bf', '#e5e7eb'], borderWidth: 0 },
-    ],
-  };
 
   const filteredRows = useMemo(() => {
     return rows
@@ -198,9 +193,7 @@ export default function Dashboard() {
                 </p>
                 <p className="text-2xl font-bold">{total}</p>
               </div>
-              <div className="w-20 h-20">
-                <Doughnut data={donutTotalData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
-              </div>
+              <OutcomeDonut />
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add `/predict/summary` endpoint to provide fraud/cleared/rare counts
- create `OutcomeDonut` component for real‑time donut chart
- display new donut in dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bed3724288327988b434d99a73740