### PR TITLE
Add real-time prescription summary donut

### DIFF
--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Doughnut } from 'react-chartjs-2';
+import { useEffect, useMemo, useState } from "react";
+import { Doughnut } from "react-chartjs-2";
 import {
   Chart as ChartJS,
   ArcElement,
@@ -9,11 +9,11 @@ import {
   LineElement,
   Tooltip,
   Legend,
-} from 'chart.js';
-import FraudInsightsPanel from '../components/FraudInsightsPanel';
-import RiskTrendChart from '../components/RiskTrendChart';
-import FlaggedTable from '../components/FlaggedTable';
-import MiniFraudFeed from '../components/MiniFraudFeed';
+} from "chart.js";
+import FraudInsightsPanel from "../components/FraudInsightsPanel";
+import RiskTrendChart from "../components/RiskTrendChart";
+import FlaggedTable from "../components/FlaggedTable";
+import MiniFraudFeed from "../components/MiniFraudFeed";
 
 ChartJS.register(
   ArcElement,
@@ -22,7 +22,7 @@ ChartJS.register(
   PointElement,
   LineElement,
   Tooltip,
-  Legend
+  Legend,
 );
 
 export default function Dashboard() {
@@ -30,37 +30,41 @@ export default function Dashboard() {
   const [fraudPct, setFraudPct] = useState(0);
   const [fraudCount, setFraudCount] = useState(0);
   const [total, setTotal] = useState(0);
+  const [summary, setSummary] = useState({ fraud: 0, cleared: 0, rare: 0 });
   const [trendChart, setTrendChart] = useState({
     labels: [],
     datasets: [
       {
         data: [],
-        borderColor: '#dc2626',
-        backgroundColor: 'rgba(220,38,38,0.2)',
+        borderColor: "#dc2626",
+        backgroundColor: "rgba(220,38,38,0.2)",
         tension: 0.4,
         fill: true,
         pointRadius: 0,
       },
     ],
   });
-  const [lastUpdated, setLastUpdated] = useState('');
-  const [statusFilter, setStatusFilter] = useState('All');
-  const [search, setSearch] = useState('');
+  const [lastUpdated, setLastUpdated] = useState("");
+  const [summaryUpdated, setSummaryUpdated] = useState("");
+  const [statusFilter, setStatusFilter] = useState("All");
+  const [search, setSearch] = useState("");
   const [selectedRow, setSelectedRow] = useState(null);
 
   const handleBypass = async () => {
     if (!selectedRow) return;
     try {
-      const res = await fetch('http://localhost:8000/predict/bypass', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const res = await fetch("http://localhost:8000/predict/bypass", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ patient_id: selectedRow.patient }),
       });
       if (res.ok) {
         setRows((prev) =>
           prev.map((r) =>
-            r.id === selectedRow.id ? { ...r, rare: true, status: 'Cleared' } : r
-          )
+            r.id === selectedRow.id
+              ? { ...r, rare: true, status: "Cleared" }
+              : r,
+          ),
         );
         setSelectedRow(null);
       }
@@ -70,48 +74,49 @@ export default function Dashboard() {
   };
 
   const exportCsv = () => {
-    const header = 'id,patient,doctor,status\n';
+    const header = "id,patient,doctor,status\n";
     const rowsData = filteredRows
-      .filter((r) => r.status === 'Flagged')
+      .filter((r) => r.status === "Flagged")
       .map((r) => `${r.id},${r.patient},${r.doctor},${r.status}`)
-      .join('\n');
-    const blob = new Blob([header + rowsData], { type: 'text/csv' });
+      .join("\n");
+    const blob = new Blob([header + rowsData], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = 'flagged.csv';
+    a.download = "flagged.csv";
     a.click();
     URL.revokeObjectURL(url);
   };
 
   useEffect(() => {
-    fetch('http://localhost:8000/predict/history')
+    fetch("http://localhost:8000/predict/history")
       .then((res) => res.json())
       .then((data) => {
         setRows(
           data.map((r, i) => ({
-            id: `RX${String(i + 1).padStart(3, '0')}`,
+            id: `RX${String(i + 1).padStart(3, "0")}`,
             patient: r.PATIENT_med,
-            status: r.fraud === 'True' || r.fraud === true ? 'Flagged' : 'Cleared',
+            status:
+              r.fraud === "True" || r.fraud === true ? "Flagged" : "Cleared",
             risk: Math.min(5, Math.round(Number(r.risk_score) / 20)),
             doctor: r.PROVIDER,
             medication: r.DESCRIPTION_med,
             rare: Array.isArray(r.flags)
-              ? r.flags.includes('Patient is exempted due to a known rare condition')
-              : r.flags?.includes('rare condition'),
-          }))
+              ? r.flags.includes(
+                  "Patient is exempted due to a known rare condition",
+                )
+              : r.flags?.includes("rare condition"),
+          })),
         );
         const totalRecords = data.length;
         const fraudRecords = data.filter(
-          (d) => d.fraud === 'True' || d.fraud === true
+          (d) => d.fraud === "True" || d.fraud === true,
         ).length;
         setTotal(totalRecords);
         setFraudCount(fraudRecords);
         setFraudPct(
-          totalRecords ? Math.round((fraudRecords / totalRecords) * 100) : 0
+          totalRecords ? Math.round((fraudRecords / totalRecords) * 100) : 0,
         );
-
-
 
         const sortedRows = [...data]
           .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
@@ -120,9 +125,9 @@ export default function Dashboard() {
           ...prev,
           labels: sortedRows.map((r) =>
             new Date(r.timestamp).toLocaleTimeString([], {
-              hour: '2-digit',
-              minute: '2-digit',
-            })
+              hour: "2-digit",
+              minute: "2-digit",
+            }),
           ),
           datasets: [
             {
@@ -136,31 +141,67 @@ export default function Dashboard() {
       .catch((err) => console.error(err));
   }, []);
 
+  useEffect(() => {
+    const fetchSummary = () => {
+      fetch("http://localhost:8000/analytics/summary")
+        .then((res) => res.json())
+        .then((data) => {
+          setSummary(data);
+          const totalCount = data.fraud + data.cleared + data.rare;
+          setTotal(totalCount);
+          setFraudCount(data.fraud);
+          setFraudPct(
+            totalCount ? Math.round((data.fraud / totalCount) * 100) : 0,
+          );
+          setSummaryUpdated(new Date().toLocaleString());
+        })
+        .catch((err) => console.error(err));
+    };
+    fetchSummary();
+    const id = setInterval(fetchSummary, 10000);
+    return () => clearInterval(id);
+  }, []);
+
   const donutFraudData = {
-    labels: ['Fraud', 'Other'],
+    labels: ["Fraud", "Other"],
     datasets: [
-      { data: [fraudPct, 100 - fraudPct], backgroundColor: ['#dc2626', '#e5e7eb'], borderWidth: 0 },
+      {
+        data: [fraudPct, 100 - fraudPct],
+        backgroundColor: ["#dc2626", "#e5e7eb"],
+        borderWidth: 0,
+      },
     ],
   };
   const donutMiddleData = {
-    labels: ['Risk', 'Other'],
+    labels: ["Risk", "Other"],
     datasets: [
-      { data: [fraudPct, 100 - fraudPct], backgroundColor: ['#0ea5e9', '#e5e7eb'], borderWidth: 0 },
+      {
+        data: [fraudPct, 100 - fraudPct],
+        backgroundColor: ["#0ea5e9", "#e5e7eb"],
+        borderWidth: 0,
+      },
     ],
   };
   const donutTotalData = {
-    labels: ['Total'],
+    labels: ["Fraud", "Cleared", "Rare"],
     datasets: [
-      { data: [100, 0], backgroundColor: ['#2dd4bf', '#e5e7eb'], borderWidth: 0 },
+      {
+        data: [summary.fraud, summary.cleared, summary.rare],
+        backgroundColor: ["#dc2626", "#16a34a", "#eab308"],
+        borderWidth: 0,
+      },
     ],
   };
 
   const filteredRows = useMemo(() => {
     return rows
-      .filter((r) => (statusFilter === 'All' ? true : r.status === statusFilter))
       .filter((r) =>
-        r.id.toLowerCase().includes(search.toLowerCase()) ||
-        r.patient.toLowerCase().includes(search.toLowerCase())
+        statusFilter === "All" ? true : r.status === statusFilter,
+      )
+      .filter(
+        (r) =>
+          r.id.toLowerCase().includes(search.toLowerCase()) ||
+          r.patient.toLowerCase().includes(search.toLowerCase()),
       );
   }, [rows, statusFilter, search]);
 
@@ -168,7 +209,7 @@ export default function Dashboard() {
     <div className="space-y-6">
       <h1
         className="text-center font-bold text-3xl md:text-4xl"
-        style={{ color: '#2F5597' }}
+        style={{ color: "#2F5597" }}
       >
         AI-Powered Prescription Fraud Detection Dashboard
       </h1>
@@ -178,29 +219,83 @@ export default function Dashboard() {
           <div className="grid sm:grid-cols-3 gap-4">
             <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
               <div>
-                <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
+                <p
+                  className="text-sm font-semibold"
+                  style={{ color: "#2F5597" }}
+                >
                   Total Fraud Cases
                 </p>
                 <p className="text-2xl font-bold text-red-500">{fraudCount}</p>
               </div>
               <div className="w-20 h-20">
-                <Doughnut data={donutFraudData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
+                <Doughnut
+                  data={donutFraudData}
+                  options={{
+                    plugins: { legend: { display: false } },
+                    cutout: "70%",
+                  }}
+                />
               </div>
             </div>
             <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-center">
               <div className="w-20 h-20">
-                <Doughnut data={donutMiddleData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
+                <Doughnut
+                  data={donutMiddleData}
+                  options={{
+                    plugins: { legend: { display: false } },
+                    cutout: "70%",
+                  }}
+                />
               </div>
             </div>
             <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
               <div>
-                <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
+                <p
+                  className="text-sm font-semibold"
+                  style={{ color: "#2F5597" }}
+                >
                   Total Prescriptions
                 </p>
                 <p className="text-2xl font-bold">{total}</p>
               </div>
-              <div className="w-20 h-20">
-                <Doughnut data={donutTotalData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
+              <div className="flex flex-col items-center">
+                <div className="w-20 h-20 relative">
+                  <Doughnut
+                    data={donutTotalData}
+                    options={{
+                      plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                          callbacks: {
+                            label: (ctx) => {
+                              const total = ctx.dataset.data.reduce(
+                                (a, b) => a + b,
+                                0,
+                              );
+                              const val = ctx.parsed;
+                              const pct = total
+                                ? ((val / total) * 100).toFixed(1)
+                                : 0;
+                              return `${ctx.label}: ${val} (${pct}%)`;
+                            },
+                          },
+                        },
+                      },
+                      cutout: "70%",
+                    }}
+                  />
+                  <div className="absolute inset-0 flex items-center justify-center text-xs">
+                    Total: {total}
+                  </div>
+                </div>
+                <div className="text-xs mt-1 flex gap-1">
+                  <span className="text-red-400">● Fraud</span>
+                  <span className="text-green-400">● Cleared</span>
+                  <span className="text-yellow-400">● Rare</span>
+                </div>
+                <p className="text-xs text-gray-400 mt-1">
+                  Last updated {summaryUpdated}
+                </p>
               </div>
             </div>
           </div>
@@ -210,7 +305,7 @@ export default function Dashboard() {
 
           {/* Risk Trend */}
           <div className="bg-gray-800 p-4 rounded-lg">
-            <h3 className="font-semibold mb-4" style={{ color: '#2F5597' }}>
+            <h3 className="font-semibold mb-4" style={{ color: "#2F5597" }}>
               Real Time Risk Score Trend
             </h3>
             <RiskTrendChart data={trendChart} lastUpdated={lastUpdated} />
@@ -219,7 +314,7 @@ export default function Dashboard() {
 
         {/* Right Panel */}
         <div className="bg-gray-800 p-4 rounded-lg space-y-4">
-          <h3 className="font-semibold" style={{ color: '#2F5597' }}>
+          <h3 className="font-semibold" style={{ color: "#2F5597" }}>
             Patient Prescriptions
           </h3>
           <FlaggedTable
@@ -230,7 +325,7 @@ export default function Dashboard() {
             onSearchChange={setSearch}
             onReview={(r) => setSelectedRow(r)}
           />
-          <h3 className="font-semibold" style={{ color: '#2F5597' }}>
+          <h3 className="font-semibold" style={{ color: "#2F5597" }}>
             Recent Flagged Medicines
           </h3>
           <MiniFraudFeed />
@@ -244,9 +339,15 @@ export default function Dashboard() {
         Export
       </button>
       {selectedRow && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setSelectedRow(null)}>
-          <div className="bg-gray-800 p-6 rounded-lg w-80" onClick={(e) => e.stopPropagation()}>
-            <h4 className="font-semibold mb-2" style={{ color: '#2F5597' }}>
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+          onClick={() => setSelectedRow(null)}
+        >
+          <div
+            className="bg-gray-800 p-6 rounded-lg w-80"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h4 className="font-semibold mb-2" style={{ color: "#2F5597" }}>
               Prescription {selectedRow.id}
             </h4>
             <p className="text-sm mb-2">Patient: {selectedRow.patient}</p>


### PR DESCRIPTION
## Summary
- implement `/analytics/summary` API to expose fraud, cleared and rare counts
- poll the new endpoint on the dashboard
- replace the "Total Prescriptions" donut with a multi-segment chart
- show a legend and timestamp below the chart

## Testing
- `python3 -m py_compile Backend/analytics.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bf04071f4832789540eab9344488a