### PR TITLE
Reorder donut charts on dashboard

### DIFF
--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -237,17 +237,6 @@ export default function Dashboard() {
                 />
               </div>
             </div>
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-center min-h-[12rem]">
-              <div className="w-20 h-20">
-                <Doughnut
-                  data={donutMiddleData}
-                  options={{
-                    plugins: { legend: { display: false } },
-                    cutout: "70%",
-                  }}
-                />
-              </div>
-            </div>
             <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between min-h-[12rem]">
               <div>
                 <p
@@ -296,6 +285,17 @@ export default function Dashboard() {
                 <p className="text-xs text-gray-400 mt-2">
                   Last updated {summaryUpdated}
                 </p>
+              </div>
+            </div>
+            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-center min-h-[12rem]">
+              <div className="w-20 h-20">
+                <Doughnut
+                  data={donutMiddleData}
+                  options={{
+                    plugins: { legend: { display: false } },
+                    cutout: "70%",
+                  }}
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- swap donut tiles on dashboard so that **Total Prescriptions** appears in the center of the top row
- move the unlabeled donut chart to the right side

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bff6788ac8327a22ae31c647061e8