### PR TITLE
Fix jsonable encoder numpy scalar issue

### DIFF
--- a/Backend/ml_model_api.py
+++ b/Backend/ml_model_api.py
@@ -173,10 +173,10 @@ def predict_fraud(input: FraudInput):
 
     return jsonable_encoder({
         "fraud": bool(score < 0),
-        "risk_score": norm_score,
+        "risk_score": int(norm_score),
         "medication_risk": risk_category,
         "used_model": model_type,
-        "HIGH_RISK_COUNT": entry["HIGH_RISK_COUNT"],
-        "UNIQUE_DOCTOR_COUNT": entry["UNIQUE_DOCTOR_COUNT"],
-        "TIME_SINCE_LAST": entry["TIME_SINCE_LAST"]
+        "HIGH_RISK_COUNT": int(entry["HIGH_RISK_COUNT"]),
+        "UNIQUE_DOCTOR_COUNT": int(entry["UNIQUE_DOCTOR_COUNT"]),
+        "TIME_SINCE_LAST": int(entry["TIME_SINCE_LAST"])
     })


### PR DESCRIPTION
## Summary
- fix returning numpy scalars in FastAPI output

## Testing
- `python -m py_compile Backend/ml_model_api.py Backend/model_predict.py`

------
https://chatgpt.com/codex/tasks/task_e_686c136f3f648327a08670bccd7d42a4