### PR TITLE
Add dashboard summary cards

### DIFF
--- a/Backend/analytics.py
+++ b/Backend/analytics.py
@@ -6,6 +6,65 @@ analytics_router = APIRouter()
 
 PRED_FILE = Path(__file__).parent / "predictions.csv"
 
+@analytics_router.get("/summary")
+def summary_data():
+    """Return summary metrics for dashboard cards."""
+    if not PRED_FILE.is_file():
+        return {
+            "total_prescriptions": 0,
+            "prescriptions_over_time": [],
+            "fraud_alerts": 0,
+            "alerts_over_time": [],
+            "avg_risk_score": 0,
+        }
+
+    df = pd.read_csv(PRED_FILE, parse_dates=["timestamp"])
+    df = df.dropna(subset=["timestamp"])
+    df["risk_score"] = pd.to_numeric(df.get("risk_score"), errors="coerce")
+    df["date"] = df["timestamp"].dt.date
+
+    total = len(df)
+
+    fraud_col = "fraud" if "fraud" in df.columns else None
+    alt_col = "likely_fraud" if "likely_fraud" in df.columns else None
+    if fraud_col:
+        fraud_df = df[df[fraud_col].astype(str).str.lower() == "true"]
+    elif alt_col:
+        fraud_df = df[df[alt_col].astype(str).str.lower() == "true"]
+    else:
+        fraud_df = df.iloc[0:0]
+
+    fraud_alerts = len(fraud_df)
+    avg_risk = round(df["risk_score"].mean(), 2) if not df["risk_score"].empty else 0
+
+    one_week_ago = pd.Timestamp.now().normalize() - pd.Timedelta(days=6)
+    recent = df[df["timestamp"] >= one_week_ago]
+
+    presc_daily = (
+        recent.groupby("date").size().reset_index(name="count").sort_values("date")
+    )
+    alerts_daily = (
+        recent.loc[fraud_df.index]
+        .groupby("date")
+        .size()
+        .reset_index(name="count")
+        .sort_values("date")
+    )
+
+    return {
+        "total_prescriptions": int(total),
+        "prescriptions_over_time": [
+            {"date": d.strftime("%Y-%m-%d"), "count": int(c)}
+            for d, c in zip(presc_daily["date"], presc_daily["count"])
+        ],
+        "fraud_alerts": int(fraud_alerts),
+        "alerts_over_time": [
+            {"date": d.strftime("%Y-%m-%d"), "count": int(c)}
+            for d, c in zip(alerts_daily["date"], alerts_daily["count"])
+        ],
+        "avg_risk_score": float(avg_risk),
+    }
+
 @analytics_router.get("/top_providers")
 def top_providers():
     """Return top 5 providers dispensing fraud-flagged meds."""

--- a/Frontend/src/components/SummaryCards.jsx
+++ b/Frontend/src/components/SummaryCards.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { Line, Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Tooltip,
+  Legend,
+);
+
+export default function SummaryCards() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchData = () => {
+    fetch('http://localhost:8000/analytics/summary')
+      .then((res) => res.json())
+      .then((d) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load metrics');
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500">{error}</div>;
+  }
+
+  const prescLine = {
+    labels: data.prescriptions_over_time.map((p) => p.date),
+    datasets: [
+      {
+        data: data.prescriptions_over_time.map((p) => p.count),
+        borderColor: '#3b82f6',
+        backgroundColor: 'rgba(59,130,246,0.2)',
+        tension: 0.4,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  const alertsBar = {
+    labels: data.alerts_over_time.map((a) => a.date),
+    datasets: [
+      {
+        data: data.alerts_over_time.map((a) => a.count),
+        backgroundColor: '#dc2626',
+        borderWidth: 0,
+      },
+    ],
+  };
+
+  const chartOptions = {
+    plugins: { legend: { display: false }, tooltip: { enabled: false } },
+    scales: { x: { display: false }, y: { display: false } },
+  };
+
+  const stars = [];
+  const rating = Math.round(data.avg_risk_score);
+  for (let i = 1; i <= 5; i += 1) {
+    stars.push(
+      <span key={i} className={i <= rating ? 'text-yellow-400' : 'text-gray-500'}>
+        ★
+      </span>,
+    );
+  }
+
+  return (
+    <div className="grid sm:grid-cols-3 gap-4">
+      <div className="bg-gray-800 rounded-lg p-4 text-center">
+        <h3 className="text-sm font-semibold text-gray-300 mb-2">Prescriptions Scanned</h3>
+        <p className="text-2xl font-bold mb-2">{data.total_prescriptions}</p>
+        <Line data={prescLine} options={chartOptions} />
+      </div>
+      <div className="bg-gray-800 rounded-lg p-4 text-center">
+        <h3 className="text-sm font-semibold text-gray-300 mb-2">Fraud Alerts Triggered</h3>
+        <p className="text-2xl font-bold mb-2 text-red-500">{data.fraud_alerts}</p>
+        <Bar data={alertsBar} options={chartOptions} />
+      </div>
+      <div className="bg-gray-800 rounded-lg p-4 text-center">
+        <h3 className="text-sm font-semibold text-gray-300 mb-2">Avg. Fraud Risk Score</h3>
+        <div className="flex justify-center mb-1 text-lg">{stars}</div>
+        <div className="w-full bg-gray-700 rounded h-2 mb-1">
+          <div
+            className="bg-yellow-500 h-2 rounded"
+            style={{ width: `${(data.avg_risk_score / 5) * 100}%` }}
+          />
+        </div>
+        <p className="text-sm text-gray-400">{data.avg_risk_score.toFixed(1)} / 5</p>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ import FraudInsightsPanel from '../components/FraudInsightsPanel';
 import RiskTrendChart from '../components/RiskTrendChart';
 import FlaggedTable from '../components/FlaggedTable';
 import MiniFraudFeed from '../components/MiniFraudFeed';
+import SummaryCards from '../components/SummaryCards';
 
 ChartJS.register(
   ArcElement,
@@ -172,6 +173,7 @@ export default function Dashboard() {
       >
         AI-Powered Prescription Fraud Detection Dashboard
       </h1>
+      <SummaryCards />
       <div className="md:grid md:grid-cols-[55%_45%] gap-6">
         <div className="space-y-6">
           {/* Row 1 */}


### PR DESCRIPTION
## Summary
- create `/analytics/summary` endpoint for aggregated metrics
- add `SummaryCards` React component fetching metrics with charts
- integrate cards at top of dashboard

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686cf116ee188327a2c2c7b50cf8feb2