### PR TITLE
Fix summary analytics indexing

### DIFF
--- a/Backend/analytics.py
+++ b/Backend/analytics.py
@@ -43,9 +43,9 @@ def summary_data():
     presc_daily = (
         recent.groupby("date").size().reset_index(name="count").sort_values("date")
     )
+    fraud_recent = fraud_df[fraud_df["timestamp"] >= one_week_ago]
     alerts_daily = (
-        recent.loc[fraud_df.index]
-        .groupby("date")
+        fraud_recent.groupby("date")
         .size()
         .reset_index(name="count")
         .sort_values("date")


### PR DESCRIPTION
## Summary
- ensure fraud alerts are filtered by date when generating daily totals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf3cd5a388327a925ace9ca6881f2