### PR TITLE
Revamp fraud risk gauge

### DIFF
--- a/Frontend/src/components/AverageRiskGauge.jsx
+++ b/Frontend/src/components/AverageRiskGauge.jsx
@@ -2,20 +2,34 @@ import PropTypes from 'prop-types';
 import ReactSpeedometer from 'react-d3-speedometer';
 
 export default function AverageRiskGauge({ value }) {
+  const stops = [0, 1.5, 3.5, 5];
   return (
-    <ReactSpeedometer
-      minValue={0}
-      maxValue={5}
-      value={value}
-      segments={3}
-      segmentColors={["#10b981", "#facc15", "#ef4444"]}
-      needleColor="#e5e7eb"
-      ringWidth={20}
-      textColor="#ffffff"
-      width={140}
-      height={100}
-      currentValueText=""
-    />
+    <div
+      className="relative flex flex-col items-center justify-center"
+      title="Average fraud severity across recent flagged prescriptions."
+    >
+      <ReactSpeedometer
+        minValue={0}
+        maxValue={5}
+        value={value}
+        customSegmentStops={stops}
+        segmentColors={["#22c55e", "#eab308", "#ef4444"]}
+        ringWidth={12}
+        width={160}
+        height={120}
+        needleColor="#f3f4f6"
+        needleTransition="easeQuadInOut"
+        needleTransitionDuration={1000}
+        currentValueText=""
+        textColor="#d1d5db"
+        maxSegmentLabels={6}
+        labelFontSize="10px"
+      />
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <div className="text-xl font-semibold text-white">{value.toFixed(2)}</div>
+        <div className="text-sm text-slate-400">out of 5</div>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- enhance AverageRiskGauge with custom coloring and ticks
- show numeric value overlay
- auto-refresh dashboard metrics every 10s
- tweak gauge card title styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cf92122dc83279ffa8f3cff0daa94