### PR TITLE
Enhance fraud risk gauge

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -5,6 +5,8 @@ from model_predict import model_router
 from users import user_router
 from analytics import analytics_router
 from prescription_api import router as prescription_router
+from pathlib import Path
+import pandas as pd
 
 app = FastAPI()
 
@@ -26,3 +28,20 @@ app.include_router(model_router, prefix="/predict")
 app.include_router(user_router, prefix="/user")
 app.include_router(analytics_router, prefix="/analytics")
 app.include_router(prescription_router, prefix="/api")
+
+PRED_FILE = Path(__file__).parent / "predictions.csv"
+
+
+@app.get("/prediction-history")
+def prediction_history():
+    """Return average fraud score scaled 0-1."""
+    if not PRED_FILE.is_file():
+        return {"avg_fraud_score": 0}
+    df = pd.read_csv(PRED_FILE, usecols=["risk_score"]).dropna()
+    df["risk_score"] = pd.to_numeric(df["risk_score"], errors="coerce")
+    df = df.dropna(subset=["risk_score"])
+    if df.empty:
+        avg = 0.0
+    else:
+        avg = df["risk_score"].astype(float).mean() / 100
+    return {"avg_fraud_score": round(float(avg), 4)}

--- a/Frontend/src/components/AverageRiskGauge.jsx
+++ b/Frontend/src/components/AverageRiskGauge.jsx
@@ -1,33 +1,49 @@
 import PropTypes from 'prop-types';
-import ReactSpeedometer from 'react-d3-speedometer';
+import ReactSpeedometer, { CustomSegmentLabelPosition } from 'react-d3-speedometer';
+
+function mapScoreToGauge(value) {
+  if (value <= 1.5) {
+    return (value / 1.5) * 1.25;
+  }
+  if (value <= 3.5) {
+    return value - 0.25;
+  }
+  return 3.25 + ((value - 3.5) * 1.75) / 1.5;
+}
 
 export default function AverageRiskGauge({ value }) {
-  const stops = [0, 1.5, 3.5, 5];
+  const stops = [0, 1.25, 3.25, 5];
+  const gaugeValue = mapScoreToGauge(value);
   return (
-    <div
-      className="relative flex flex-col items-center justify-center"
-      title="Average fraud severity across recent flagged prescriptions."
-    >
+    <div className="relative flex flex-col items-center justify-center w-full max-w-[200px] group" title="Average fraud severity across recent flagged prescriptions.">
+      <div className="absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap text-xs bg-gray-700 text-white px-2 py-1 rounded opacity-0 group-hover:opacity-100">
+        This reflects the average fraud severity across all flagged prescriptions.
+      </div>
       <ReactSpeedometer
         minValue={0}
         maxValue={5}
-        value={value}
+        value={gaugeValue}
         customSegmentStops={stops}
         segmentColors={["#22c55e", "#eab308", "#ef4444"]}
         ringWidth={12}
-        width={160}
+        fluidWidth
         height={120}
         needleColor="#f3f4f6"
         needleTransition="easeQuadInOut"
-        needleTransitionDuration={1000}
+        needleTransitionDuration={300}
         currentValueText=""
         textColor="#d1d5db"
-        maxSegmentLabels={6}
-        labelFontSize="10px"
+        customSegmentLabels={[
+          { text: '0', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
+          { text: '1.5', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
+          { text: '3.5', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
+          { text: '5', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
+        ]}
+        labelFontSize="11px"
       />
-      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-        <div className="text-xl font-semibold text-white">{value.toFixed(2)}</div>
-        <div className="text-sm text-slate-400">out of 5</div>
+      <div className="absolute inset-0 flex flex-col items-center justify-end pb-2 pointer-events-none">
+        <p className="text-white text-2xl font-semibold mt-2">{value.toFixed(2)}</p>
+        <p className="text-slate-400 text-sm">out of 5</p>
       </div>
     </div>
   );

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -112,10 +112,18 @@ export default function Dashboard() {
           setFraudCount(fraudRecords);
           setFraudPct(totalRecords ? Math.round((fraudRecords / totalRecords) * 100) : 0);
 
-          const avg =
-            data.reduce((sum, r) => sum + Number(r.risk_score || 0), 0) /
-            (totalRecords || 1);
-          setAvgRisk(Number((avg / 20).toFixed(2)));
+          fetch('http://localhost:8000/prediction-history')
+            .then(res => res.json())
+            .then(hist => {
+              const avgScore = Number(hist.avg_fraud_score || 0);
+              setAvgRisk(Number((avgScore * 5).toFixed(2)));
+            })
+            .catch(() => {
+              const avg =
+                data.reduce((sum, r) => sum + Number(r.risk_score || 0), 0) /
+                (totalRecords || 1);
+              setAvgRisk(Number((avg / 20).toFixed(2)));
+            });
 
           const sortedRows = [...data]
             .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
@@ -191,9 +199,7 @@ export default function Dashboard() {
               </div>
             </div>
             <div className="bg-gray-800 p-4 rounded-lg flex flex-col items-center justify-center text-center">
-              <p className="text-md font-medium text-slate-300 text-center mb-1">
-                Avg. Fraud Risk
-              </p>
+              <h3 className="text-md font-medium text-slate-300 text-center mb-1">Avg. Fraud Risk</h3>
               <AverageRiskGauge value={avgRisk} />
             </div>
             <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">


### PR DESCRIPTION
## Summary
- add `/prediction-history` endpoint for avg fraud score
- refresh Avg. Fraud Risk gauge styling
- fetch average from API and show in dashboard

## Testing
- `npm run lint`
- `npm run build`
- `python3 -m py_compile Backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686cfb5bc90c8327b989d0ae2131c858