### PR TITLE
Fix key warnings and gauge labels

### DIFF
--- a/Frontend/src/components/RiskGauge.jsx
+++ b/Frontend/src/components/RiskGauge.jsx
@@ -3,12 +3,12 @@ import ReactSpeedometer from 'react-d3-speedometer';
 
 export default function RiskGauge({ value }) {
   const maxValue = 100;
-  const segments = 3;
   const customSegmentLabels = [
     { text: 'Low', position: 'INSIDE', color: '#22c55e' },
     { text: 'Medium', position: 'INSIDE', color: '#eab308' },
     { text: 'High', position: 'INSIDE', color: '#ef4444' },
   ];
+  const segments = customSegmentLabels.length;
 
   return (
     <ReactSpeedometer
@@ -21,6 +21,7 @@ export default function RiskGauge({ value }) {
       needleTransitionDuration={1000}
       needleColor="#374151"
       textColor="#ffffff"
+      forceRender
     />
   );
 }

--- a/Frontend/src/components/TrendingBanner.jsx
+++ b/Frontend/src/components/TrendingBanner.jsx
@@ -9,7 +9,7 @@ export default function TrendingBanner() {
     <div className="bg-gradient-to-r from-pink-500 to-yellow-500 overflow-hidden">
       <div className="whitespace-nowrap flex animate-marquee py-2">
         {items.concat(items).map((item, idx) => (
-          <span key={idx} className="text-white font-bold mx-4">
+          <span key={`${item}-${idx}`} className="text-white font-bold mx-4">
             {item}
           </span>
         ))}

--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -125,8 +125,8 @@ export default function Home() {
 
       {/* Top KPI Cards */}
       <div className="grid gap-6 md:grid-cols-3">
-        {kpis.map((kpi) => (
-          <div key={kpi.label} className="bg-gray-800 p-4 rounded-lg shadow flex items-center justify-between transition-transform hover:scale-105">
+        {kpis.map((kpi, idx) => (
+          <div key={`${kpi.label}-${idx}`} className="bg-gray-800 p-4 rounded-lg shadow flex items-center justify-between transition-transform hover:scale-105">
             <div>
               <p className="text-sm text-gray-400">{kpi.label}</p>
               <p className="text-2xl font-semibold text-white">{kpi.value}</p>
@@ -152,7 +152,7 @@ export default function Home() {
         </div>
         <ul className="space-y-2 text-sm">
           {medsData.labels.map((label, idx) => (
-            <li key={label} className="flex items-center gap-2">
+            <li key={`${label}-${idx}`} className="flex items-center gap-2">
               <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: medsData.datasets[0].backgroundColor[idx] }}></span>
               {label}
             </li>
@@ -186,7 +186,7 @@ export default function Home() {
                 </td>
                 <td className="py-2">
                   {Array.from({ length: 5 }).map((_, i) => (
-                    <Star key={i} className={`w-4 h-4 inline ${i < row.risk ? 'text-yellow-400' : 'text-gray-300'}`} />
+                    <Star key={`${row.id}-${i}`} className={`w-4 h-4 inline ${i < row.risk ? 'text-yellow-400' : 'text-gray-300'}`} />
                   ))}
                 </td>
                 <td className="py-2">


### PR DESCRIPTION
## Summary
- ensure RiskGauge segments auto-align with labels
- fix missing keys in TrendingBanner and Home tables
- force ReactSpeedometer to fully render

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d00d7f27c832796231e4e92a66e7d