### PR TITLE
Fix key warning and gauge labels

### DIFF
--- a/Frontend/src/components/AverageRiskGauge.jsx
+++ b/Frontend/src/components/AverageRiskGauge.jsx
@@ -34,10 +34,9 @@ export default function AverageRiskGauge({ value }) {
         currentValueText=""
         textColor="#d1d5db"
         customSegmentLabels={[
-          { text: '0', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
-          { text: '1.5', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
-          { text: '3.5', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
-          { text: '5', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
+          { text: 'Low', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
+          { text: 'Medium', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
+          { text: 'High', position: CustomSegmentLabelPosition.Outside, fontSize: '11px' },
         ]}
         labelFontSize="11px"
       />

--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -280,9 +280,8 @@ export default function Home() {
                   .includes(filter.toLowerCase())
               )
               .map((row) => (
-              <>
+              <React.Fragment key={row.id}>
                 <tr
-                  key={row.id}
                   className="border-t hover:bg-gray-700 transition-colors"
                 >
                   <td className="py-2 font-medium">{row.id}</td>
@@ -341,7 +340,7 @@ export default function Home() {
                     </td>
                   </tr>
                 )}
-              </>
+              </React.Fragment>
             ))}
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- ensure table rows in `Home` use keyed React Fragments
- update gauge to match API expectations

## Testing
- `npm run lint`
- `python -m unittest discover Backend`

------
https://chatgpt.com/codex/tasks/task_e_686d023a3378832791bc61fe05d94683