### PR TITLE
Add average fraud risk gauge

### DIFF
--- a/Frontend/src/components/AvgFraudGauge.jsx
+++ b/Frontend/src/components/AvgFraudGauge.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import Plot from 'react-plotly.js';
+
+export default function AvgFraudGauge() {
+  const [avg, setAvg] = useState(0);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/predict/history')
+      .then(res => res.json())
+      .then(list => {
+        const scores = list
+          .map(r => Number(r.risk_score))
+          .filter(n => !Number.isNaN(n));
+        if (!scores.length) return;
+        const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length;
+        setAvg(Number((avgScore / 20).toFixed(2)));
+      })
+      .catch(err => console.error(err));
+  }, []);
+
+  const color = avg < 1.5 ? '#16a34a' : avg < 3.5 ? '#eab308' : '#dc2626';
+
+  return (
+    <div className="flex flex-col items-center">
+      <p className="text-sm font-semibold mb-1" style={{ color: '#2F5597' }}>
+        Avg. Fraud Risk
+      </p>
+      <div className="w-24 h-24">
+        <Plot
+          data={[{
+            type: 'indicator',
+            mode: 'gauge+number',
+            value: avg,
+            number: { suffix: ' / 5', valueformat: '.2f', font: { color: '#ffffff' } },
+            gauge: {
+              axis: { range: [0, 5] },
+              bar: { color },
+              steps: [
+                { range: [0, 1.5], color: '#064e3b' },
+                { range: [1.5, 3.5], color: '#78350f' },
+                { range: [3.5, 5], color: '#7f1d1d' },
+              ],
+            },
+          }]}
+          layout={{
+            width: 100,
+            height: 80,
+            margin: { t: 10, b: 0, l: 10, r: 10 },
+            paper_bgcolor: 'transparent',
+            plot_bgcolor: 'transparent',
+            font: { color: '#ffffff' },
+          }}
+          config={{ displayModeBar: false }}
+        />
+      </div>
+      <p className="text-xs mt-1">{avg.toFixed(2)} / 5</p>
+    </div>
+  );
+}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ import FraudInsightsPanel from '../components/FraudInsightsPanel';
 import RiskTrendChart from '../components/RiskTrendChart';
 import FlaggedTable from '../components/FlaggedTable';
 import MiniFraudFeed from '../components/MiniFraudFeed';
+import AvgFraudGauge from '../components/AvgFraudGauge';
 
 ChartJS.register(
   ArcElement,
@@ -142,12 +143,6 @@ export default function Dashboard() {
       { data: [fraudPct, 100 - fraudPct], backgroundColor: ['#dc2626', '#e5e7eb'], borderWidth: 0 },
     ],
   };
-  const donutMiddleData = {
-    labels: ['Risk', 'Other'],
-    datasets: [
-      { data: [fraudPct, 100 - fraudPct], backgroundColor: ['#0ea5e9', '#e5e7eb'], borderWidth: 0 },
-    ],
-  };
   const donutTotalData = {
     labels: ['Total'],
     datasets: [
@@ -188,9 +183,7 @@ export default function Dashboard() {
               </div>
             </div>
             <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-center">
-              <div className="w-20 h-20">
-                <Doughnut data={donutMiddleData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
-              </div>
+              <AvgFraudGauge />
             </div>
             <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
               <div>


### PR DESCRIPTION
## Summary
- compute average risk score from prediction history
- show Avg. Fraud Risk speedometer gauge on the dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d04df4e948327a0837a375c4caae9