### PR TITLE
Improve Avg Fraud Gauge layout

### DIFF
--- a/Frontend/src/components/AvgFraudGauge.jsx
+++ b/Frontend/src/components/AvgFraudGauge.jsx
@@ -31,12 +31,12 @@ export default function AvgFraudGauge() {
 
 
   return (
-    <div className="flex flex-col items-center">
-      <p className="text-sm font-semibold mb-1" style={{ color: '#2F5597' }}>
+    <div className="flex flex-col items-center gap-y-2">
+      <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
         Avg. Fraud Risk
       </p>
 
-      <div className="relative w-40 h-40 drop-shadow-lg">
+      <div className="relative w-40 h-40 drop-shadow-lg pt-2">
         <ReactSpeedometer
           maxValue={5}
           value={avg}
@@ -53,13 +53,14 @@ export default function AvgFraudGauge() {
           valueTextFontSize="0px"
           width={160}
         />
-        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-          <span className="text-lg font-bold text-white drop-shadow-sm">{avg.toFixed(2)}</span>
-          <span className="text-xs text-gray-300">out of 5</span>
-        </div>
       </div>
 
-
+      <div className="mt-4 flex flex-col items-center">
+        <span className="text-3xl font-bold text-white drop-shadow-sm">
+          {avg.toFixed(2)}
+        </span>
+        <span className="text-sm text-gray-300">out of 5</span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- adjust AvgFraudGauge layout for better readability
- make gauge value larger and separate from the gauge

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d0de1b1148327954f12080247f39a