### PR TITLE
Adjust dashboard tile spacing

### DIFF
--- a/Frontend/src/components/AvgFraudGauge.jsx
+++ b/Frontend/src/components/AvgFraudGauge.jsx
@@ -36,7 +36,7 @@ export default function AvgFraudGauge() {
         Avg. Fraud Risk
       </p>
 
-      <div className="relative w-40 h-40 drop-shadow-lg pt-2">
+      <div className="relative w-20 h-20 drop-shadow-lg pt-2">
         <ReactSpeedometer
           maxValue={5}
           value={avg}
@@ -48,15 +48,15 @@ export default function AvgFraudGauge() {
           needleColor="#e2e8f0"
           needleTransition="easeElastic"
           needleTransitionDuration={1500}
-          ringWidth={20}
+          ringWidth={10}
           textColor="#ffffff"
           valueTextFontSize="0px"
-          width={160}
+          width={80}
         />
       </div>
 
       <div className="mt-4 flex flex-col items-center">
-        <span className="text-3xl font-bold text-white drop-shadow-sm">
+        <span className="text-2xl font-bold text-white drop-shadow-sm">
           {avg.toFixed(2)}
         </span>
         <span className="text-sm text-gray-300">out of 5</span>

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -171,7 +171,7 @@ export default function Dashboard() {
         <div className="space-y-6">
           {/* Row 1 */}
           <div className="grid sm:grid-cols-3 gap-4">
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+            <div className="bg-gray-800 px-4 py-2 rounded-lg flex items-center justify-between">
               <div>
                 <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
                   Total Fraud Cases
@@ -182,10 +182,10 @@ export default function Dashboard() {
                 <Doughnut data={donutFraudData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
               </div>
             </div>
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-center">
+            <div className="bg-gray-800 px-4 py-2 rounded-lg flex items-center justify-center">
               <AvgFraudGauge />
             </div>
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+            <div className="bg-gray-800 px-4 py-2 rounded-lg flex items-center justify-between">
               <div>
                 <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
                   Total Prescriptions


### PR DESCRIPTION
## Summary
- shrink gauge size in `AvgFraudGauge`
- reduce padding on dashboard top tiles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d114fca548327931387e2fec6c546