### PR TITLE
Refine AvgFraudGauge text size and positioning

### DIFF
--- a/Frontend/src/components/AvgFraudGauge.jsx
+++ b/Frontend/src/components/AvgFraudGauge.jsx
@@ -36,30 +36,32 @@ export default function AvgFraudGauge() {
         Avg. Fraud Risk
       </p>
 
-      <div className="relative w-40 h-40 drop-shadow-lg pt-2">
-        <ReactSpeedometer
-          maxValue={5}
-          value={avg}
-          minValue={0}
-          customSegmentStops={segments}
-          segmentColors={colors}
-          customSegmentLabels={labels}
-          maxSegmentLabels={0}
-          needleColor="#e2e8f0"
-          needleTransition="easeElastic"
-          needleTransitionDuration={1500}
-          ringWidth={20}
-          textColor="#ffffff"
-          valueTextFontSize="0px"
-          width={160}
-        />
-      </div>
+      <div className="flex flex-col items-center justify-center">
+        <div className="relative w-40 h-40 drop-shadow-lg pt-2">
+          <ReactSpeedometer
+            maxValue={5}
+            value={avg}
+            minValue={0}
+            customSegmentStops={segments}
+            segmentColors={colors}
+            customSegmentLabels={labels}
+            maxSegmentLabels={0}
+            needleColor="#e2e8f0"
+            needleTransition="easeElastic"
+            needleTransitionDuration={1500}
+            ringWidth={20}
+            textColor="#ffffff"
+            valueTextFontSize="0px"
+            width={160}
+          />
+        </div>
 
-      <div className="mt-4 flex flex-col items-center">
-        <span className="text-3xl font-bold text-white drop-shadow-sm">
-          {avg.toFixed(2)}
-        </span>
-        <span className="text-sm text-gray-300">out of 5</span>
+        <div className="mt-1 flex flex-col items-center">
+          <span className="text-2xl font-normal text-white drop-shadow-sm">
+            {avg.toFixed(2)}
+          </span>
+          <span className="text-sm text-gray-300">out of 5</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- move AvgFraudGauge value closer to the gauge
- reduce font size and weight for more compact look

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d1403d3cc8327bcbf70f0f06b56b2