### PR TITLE
Make dashboard summary tiles compact

### DIFF
--- a/Frontend/src/components/AvgFraudGauge.jsx
+++ b/Frontend/src/components/AvgFraudGauge.jsx
@@ -36,7 +36,7 @@ export default function AvgFraudGauge() {
         Avg. Fraud Risk
       </p>
 
-      <div className="relative w-40 h-40 drop-shadow-lg pt-2">
+      <div className="relative w-32 h-32 drop-shadow-lg pt-2">
         <ReactSpeedometer
           maxValue={5}
           value={avg}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -170,29 +170,29 @@ export default function Dashboard() {
       <div className="md:grid md:grid-cols-[55%_45%] gap-6">
         <div className="space-y-6">
           {/* Row 1 */}
-          <div className="grid sm:grid-cols-3 gap-4">
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+          <div className="grid sm:grid-cols-3 gap-3">
+            <div className="bg-gray-800 p-3 rounded-lg flex items-center justify-between shadow-md ring-1 ring-gray-700">
               <div>
                 <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
                   Total Fraud Cases
                 </p>
                 <p className="text-2xl font-bold text-red-500">{fraudCount}</p>
               </div>
-              <div className="w-20 h-20">
+              <div className="w-16 h-16">
                 <Doughnut data={donutFraudData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
               </div>
             </div>
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-center">
+            <div className="bg-gray-800 p-3 rounded-lg flex items-center justify-center shadow-md ring-1 ring-gray-700">
               <AvgFraudGauge />
             </div>
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+            <div className="bg-gray-800 p-3 rounded-lg flex items-center justify-between shadow-md ring-1 ring-gray-700">
               <div>
                 <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
                   Total Prescriptions
                 </p>
                 <p className="text-2xl font-bold">{total}</p>
               </div>
-              <div className="w-20 h-20">
+              <div className="w-16 h-16">
                 <Doughnut data={donutTotalData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- shrink donut sizes on Dashboard
- reduce spacing and add shadows around summary tiles

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d16dadd5883278ce591c5496699dd