### PR TITLE
Refine fraud gauge layout

### DIFF
--- a/Frontend/src/components/AvgFraudGauge.jsx
+++ b/Frontend/src/components/AvgFraudGauge.jsx
@@ -31,12 +31,12 @@ export default function AvgFraudGauge() {
 
 
   return (
-    <div className="flex flex-col items-center gap-y-2">
+    <div className="flex flex-col items-center justify-center gap-y-2">
       <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
         Avg. Fraud Risk
       </p>
 
-      <div className="relative w-40 h-40 drop-shadow-lg pt-2">
+      <div className="relative w-40 h-40 drop-shadow-lg border-b border-gray-700 pb-2">
         <ReactSpeedometer
           maxValue={5}
           value={avg}
@@ -55,11 +55,11 @@ export default function AvgFraudGauge() {
         />
       </div>
 
-      <div className="mt-4 flex flex-col items-center">
-        <span className="text-3xl font-bold text-white drop-shadow-sm">
+      <div className="text-center space-y-1 mt-1">
+        <span className="text-2xl font-bold text-white drop-shadow-sm">
           {avg.toFixed(2)}
         </span>
-        <span className="text-sm text-gray-300">out of 5</span>
+        <span className="text-xs text-gray-300">out of 5</span>
       </div>
     </div>
   );

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -171,7 +171,7 @@ export default function Dashboard() {
         <div className="space-y-6">
           {/* Row 1 */}
           <div className="grid sm:grid-cols-3 gap-4">
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+            <div className="bg-gray-800 py-3 px-4 rounded-lg flex items-center justify-between min-h-[180px]">
               <div>
                 <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
                   Total Fraud Cases
@@ -182,10 +182,10 @@ export default function Dashboard() {
                 <Doughnut data={donutFraudData} options={{ plugins: { legend: { display: false } }, cutout: '70%' }} />
               </div>
             </div>
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-center">
+            <div className="bg-gray-800 py-3 px-4 rounded-lg flex flex-col justify-center items-center min-h-[180px]">
               <AvgFraudGauge />
             </div>
-            <div className="bg-gray-800 p-4 rounded-lg flex items-center justify-between">
+            <div className="bg-gray-800 py-3 px-4 rounded-lg flex items-center justify-between min-h-[180px]">
               <div>
                 <p className="text-sm font-semibold" style={{ color: '#2F5597' }}>
                   Total Prescriptions


### PR DESCRIPTION
## Summary
- tighten AvgFraudGauge text under the gauge
- add subtle border and resize fonts
- shrink dashboard metric card padding and enforce consistent heights

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d1b8c0c58832795361faf17e90e7d